### PR TITLE
feat(template): scaffold aws-infra-template repository

### DIFF
--- a/.claude/scripts/aws-sso-credentials.sh
+++ b/.claude/scripts/aws-sso-credentials.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Extract and export temporary AWS credentials from SSO cache
+#
+# Usage:
+#   source aws-sso-credentials.sh
+#
+# Description:
+#   Extracts the SSO access token from ~/.aws/sso/cache/, exchanges it for
+#   temporary AWS credentials, and exports them as environment variables
+#   (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN).
+#
+#   Replace the placeholder constants below (SSO_START_URL, SSO_ROLE_NAME,
+#   SSO_ACCOUNT_ID, SSO_REGION) with values matching your AWS SSO setup.
+#
+# Example:
+#   source .claude/scripts/aws-sso-credentials.sh
+#
+
+asc_main() {
+  local sso_start_url="https://<YOUR-SSO-PORTAL>.awsapps.com/start"
+  local sso_role_name="AdministratorAccess"
+  local sso_account_id="000000000000"
+  local sso_region="eu-central-1"
+
+  echo "🔐 Extracting AWS credentials from SSO cache..."
+
+  local access_token
+  access_token=$(asc_extract_access_token "$sso_start_url") || return 1
+
+  echo "✓ Found SSO access token"
+
+  local creds
+  creds=$(asc_get_role_credentials "$sso_role_name" "$sso_account_id" "$access_token" "$sso_region") || return 1
+
+  asc_export_credentials "$creds"
+}
+
+asc_extract_access_token() {
+  local sso_start_url="$1"
+  local access_token
+
+  access_token=$(cat ~/.aws/sso/cache/*.json 2>/dev/null | \
+    jq -r "select(.startUrl == \"$sso_start_url\") | .accessToken" | \
+    head -1)
+
+  if [[ -z "$access_token" ]] || [[ "$access_token" == "null" ]]; then
+    echo "❌ Error: No valid SSO token found in cache" >&2
+    echo "   Run: aws sso login --profile \"\$AWS_PROFILE\"" >&2
+    return 1
+  fi
+
+  echo "$access_token"
+}
+
+asc_get_role_credentials() {
+  local sso_role_name="$1"
+  local sso_account_id="$2"
+  local access_token="$3"
+  local sso_region="$4"
+  local creds
+
+  creds=$(aws sso get-role-credentials \
+    --role-name "$sso_role_name" \
+    --account-id "$sso_account_id" \
+    --access-token "$access_token" \
+    --region "$sso_region" 2>/dev/null) || {
+    echo "❌ Error: Failed to get role credentials" >&2
+    echo "   Your SSO session may have expired" >&2
+    echo "   Run: aws sso login --profile \"\$AWS_PROFILE\"" >&2
+    return 1
+  }
+
+  echo "$creds"
+}
+
+asc_export_credentials() {
+  local creds="$1"
+  local aws_access_key_id
+  local aws_secret_access_key
+  local aws_session_token
+
+  aws_access_key_id=$(echo "$creds" | jq -r '.roleCredentials.accessKeyId')
+  aws_secret_access_key=$(echo "$creds" | jq -r '.roleCredentials.secretAccessKey')
+  aws_session_token=$(echo "$creds" | jq -r '.roleCredentials.sessionToken')
+
+  export AWS_ACCESS_KEY_ID="$aws_access_key_id"
+  export AWS_SECRET_ACCESS_KEY="$aws_secret_access_key"
+  export AWS_SESSION_TOKEN="$aws_session_token"
+
+  local expiration
+  expiration=$(echo "$creds" | jq -r '.roleCredentials.expiration')
+  local expiration_date
+  expiration_date=$(date -r $((expiration / 1000)) '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo "unknown")
+
+  echo "✓ AWS credentials exported to environment"
+  echo "  Access Key: ${AWS_ACCESS_KEY_ID}"
+  echo "  Expires at: ${expiration_date}"
+  echo ""
+  echo "You can now run AWS CLI and Terraform commands."
+}
+
+asc_main "$@"
+_asc_rc=$?
+unset -f asc_main asc_extract_access_token asc_get_role_credentials asc_export_credentials
+return "$_asc_rc"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(terraform fmt:*)",
+      "Bash(terraform version:*)",
+      "Bash(*/terraform fmt:*)",
+      "Bash(*/terraform version)",
+      "Bash(*/check-aws-auth.sh)",
+      "Bash(*/setup-aws-auth.sh)",
+      "Bash(*/mise:*)",
+      "WebSearch",
+      "WebFetch(domain:registry.terraform.io)"
+    ]
+  }
+}

--- a/.claude/skills/aws/README.md
+++ b/.claude/skills/aws/README.md
@@ -1,0 +1,36 @@
+# AWS Authentication Skill
+
+Helper scripts and documentation for managing AWS authentication via `AWS_PROFILE`.
+
+## Files
+
+- **SKILL.md** - Main skill documentation for Claude Code
+- **scripts/check-aws-auth.sh** - Verify AWS authentication is valid
+- **scripts/setup-aws-auth.sh** - Set up AWS profile and verify authentication
+
+## Quick Start
+
+```bash
+# Check authentication status
+.claude/skills/aws/scripts/check-aws-auth.sh
+
+# Set up authentication (should be sourced to export AWS_PROFILE)
+source .claude/skills/aws/scripts/setup-aws-auth.sh
+```
+
+## Authentication Flow
+
+1. **Check** if authentication is valid with `check-aws-auth.sh`
+2. **Export** the AWS profile: `export AWS_PROFILE=<your-profile>`
+3. **Verify** with AWS CLI: `aws sts get-caller-identity`
+4. **If expired**, user must run: `aws sso login --profile "$AWS_PROFILE"`
+
+## Integration
+
+This skill integrates with:
+
+- AWS CLI commands
+- Terraform operations (via AWS SDK)
+- Existing SSO credentials script ([.claude/scripts/aws-sso-credentials.sh](../../scripts/aws-sso-credentials.sh))
+
+See the main [CLAUDE.md](../../../CLAUDE.md) file for complete AWS authentication documentation.

--- a/.claude/skills/aws/SKILL.md
+++ b/.claude/skills/aws/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: aws
+description: Configure AWS authentication for CLI and Terraform operations
+user-invocable: false
+model: Haiku
+allowed-tools: Bash(*/setup-aws-auth.sh), Bash(*/check-aws-auth.sh)
+---
+
+# AWS Authentication Helper
+
+## Purpose
+
+This skill helps configure AWS authentication for the project's AWS profile (value of `AWS_PROFILE`, defaults to `default`), supporting both AWS CLI commands and Terraform operations.
+
+## When to Use
+
+Use this skill **before** running:
+
+- Any AWS CLI commands (`aws s3`, `aws ec2`, etc.)
+- Terraform commands that interact with AWS (`terraform plan`, `terraform apply`, etc.)
+- When authentication errors occur (expired SSO session)
+
+## How to Use
+
+### 1. Check Current Authentication Status
+
+```bash
+.claude/skills/aws/scripts/check-aws-auth.sh
+```
+
+This verifies if the current AWS authentication is valid.
+
+### 2. Set Up Authentication
+
+```bash
+# Export AWS profile (preferred method)
+export AWS_PROFILE=<your-profile>
+
+# Verify it works
+aws sts get-caller-identity
+```
+
+### 3. Handle Expired SSO Sessions
+
+If SSO session is expired, prompt the user to run:
+
+```bash
+aws sso login --profile "$AWS_PROFILE"
+```
+
+Then retry the authentication check.
+
+### 4. Alternative: Export Temporary Credentials
+
+If explicit credentials are needed (rare cases), use:
+
+```bash
+source .claude/scripts/aws-sso-credentials.sh
+```
+
+## Authentication Methods
+
+### Method 1: AWS Profile (Recommended)
+
+Most reliable for both AWS CLI and Terraform:
+
+```bash
+export AWS_PROFILE=<your-profile>
+
+# AWS CLI automatically uses the profile
+aws s3 ls
+
+# Terraform automatically uses the profile (via AWS SDK)
+terraform plan
+```
+
+### Method 2: Temporary Credentials Export
+
+For cases requiring explicit environment variables:
+
+```bash
+source .claude/scripts/aws-sso-credentials.sh
+
+# This sets: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN
+```
+
+See [@.claude/scripts/aws-sso-credentials.sh](../../scripts/aws-sso-credentials.sh) for implementation.
+
+## Error Handling
+
+### SSO Session Expired
+
+**Error**: `Error when retrieving token from sso: Token has expired`
+
+**Resolution**: Inform user to re-authenticate:
+
+```bash
+aws sso login --profile "$AWS_PROFILE"
+```
+
+### Profile Not Found
+
+**Error**: `Profile <name> could not be found`
+
+**Resolution**: Verify AWS CLI configuration file (`~/.aws/config`) contains the profile definition.
+
+### Invalid Credentials
+
+**Error**: `Unable to locate credentials`
+
+**Resolution**:
+1. Ensure `AWS_PROFILE` is exported to a configured profile
+2. Check SSO session is valid with `aws sts get-caller-identity`
+3. Re-run SSO login if needed
+
+## Best Practices
+
+1. **Always export AWS_PROFILE** at the start of terminal sessions
+2. **Verify authentication** before running expensive operations
+3. **Inform user** if SSO re-authentication is needed (can't be automated)
+4. **Use profile over credentials** - more secure and manageable
+5. **Don't print credentials** in terminal output
+
+## Integration with Terraform
+
+Terraform automatically uses `AWS_PROFILE` environment variable via the AWS SDK:
+
+```bash
+export AWS_PROFILE=<your-profile>
+terraform plan  # Uses the profile automatically
+```
+
+No additional provider configuration needed in Terraform code when using profiles.

--- a/.claude/skills/aws/scripts/check-aws-auth.sh
+++ b/.claude/skills/aws/scripts/check-aws-auth.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# Check if AWS authentication is valid for the specified profile.
+#
+# Usage:
+#   ./check-aws-auth.sh
+#
+# Environment:
+#   AWS_PROFILE   Profile name (default: default)
+#
+# Exit codes:
+#   0   Authentication valid
+#   1   Authentication invalid or missing AWS CLI
+#
+
+set -euo pipefail
+
+main() {
+  local profile="${AWS_PROFILE:-default}"
+
+  check_aws_cli_installed
+  verify_authentication "$profile"
+  display_identity "$profile"
+}
+
+check_aws_cli_installed() {
+  if ! command -v aws &> /dev/null; then
+    echo "ERROR: AWS CLI not found. Please install AWS CLI." >&2
+    exit 1
+  fi
+}
+
+verify_authentication() {
+  local profile="$1"
+  if ! aws sts get-caller-identity --profile "$profile" &> /dev/null; then
+    echo "ERROR: AWS authentication failed for profile: $profile" >&2
+    echo "  Possible causes:" >&2
+    echo "    - SSO session expired (run: aws sso login --profile $profile)" >&2
+    echo "    - Invalid credentials" >&2
+    echo "    - Profile not configured" >&2
+    exit 1
+  fi
+}
+
+display_identity() {
+  local profile="$1"
+  local identity account arn
+
+  echo "✓ AWS authentication is valid for profile: $profile"
+
+  identity=$(aws sts get-caller-identity --profile "$profile" --output json 2>/dev/null)
+  account=$(echo "$identity" | grep -o '"Account": "[^"]*"' | cut -d'"' -f4)
+  arn=$(echo "$identity" | grep -o '"Arn": "[^"]*"' | cut -d'"' -f4)
+
+  echo "  Account: $account"
+  echo "  Identity: $arn"
+}
+
+main "$@"

--- a/.claude/skills/aws/scripts/setup-aws-auth.sh
+++ b/.claude/skills/aws/scripts/setup-aws-auth.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+#
+# Set up AWS authentication by exporting AWS_PROFILE.
+#
+# Usage:
+#   source .claude/skills/aws/scripts/setup-aws-auth.sh
+#
+# Environment:
+#   AWS_PROFILE   Profile name to use (default: default)
+#
+# Effects:
+#   - Exports AWS_PROFILE (if not already set)
+#   - Verifies authentication and displays account info
+#   - Returns 1 if AWS CLI missing or authentication failed
+#
+
+saa_main() {
+  local profile="${AWS_PROFILE:-default}"
+
+  saa_export_profile "$profile"
+  saa_check_aws_cli_installed
+  saa_verify_authentication "$profile" || return 1
+  saa_display_account "$profile"
+}
+
+saa_export_profile() {
+  local profile="$1"
+  export AWS_PROFILE="$profile"
+  echo "✓ AWS_PROFILE set to: $profile"
+}
+
+saa_check_aws_cli_installed() {
+  if ! command -v aws &> /dev/null; then
+    echo "⚠ WARNING: AWS CLI not found" >&2
+    return 1
+  fi
+}
+
+saa_verify_authentication() {
+  local profile="$1"
+  if ! aws sts get-caller-identity --profile "$profile" &> /dev/null 2>&1; then
+    echo "⚠ WARNING: AWS authentication check failed" >&2
+    echo "  Run: aws sso login --profile $profile" >&2
+    aws sso login --profile "$profile"
+  fi
+}
+
+saa_display_account() {
+  local profile="$1"
+  local identity account
+
+  echo "✓ AWS authentication is valid"
+
+  identity=$(aws sts get-caller-identity --profile "$profile" --output json 2>/dev/null)
+  account=$(echo "$identity" | grep -o '"Account": "[^"]*"' | cut -d'"' -f4)
+
+  echo "✓ AWS Account: $account"
+}
+
+saa_main "$@"
+_saa_rc=$?
+unset -f saa_main saa_export_profile saa_check_aws_cli_installed saa_verify_authentication saa_display_account
+return "$_saa_rc"

--- a/.claude/skills/pr-description/SKILL.md
+++ b/.claude/skills/pr-description/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: pr-description
+description: Generate a PR description, create a feature branch if needed, and submit the PR to GitHub
+user-invocable: true
+model: Sonnet
+allowed-tools: Bash(git log:*), Bash(git diff:*), Bash(git rev-parse:*), Bash(git branch:*), Bash(git checkout:*), Bash(git push:*), Bash(gh pr create:*), Bash(gh pr view:*), Read
+---
+
+# PR Description Generator
+
+## Purpose
+
+Generate a pull request description filled from the repo's PR template, then create and
+submit the PR on GitHub via `gh pr create`.
+
+Handles two starting states:
+
+- **On a feature branch** — uses the current branch as-is.
+- **On `main`** — derives a branch name from the unmerged commit subjects, creates and
+  pushes that branch, then opens the PR.
+
+## Steps
+
+### 1. Identify unmerged commits
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+If this produces no output, tell the user there is nothing to PR and stop.
+
+### 2. Determine (or create) the feature branch
+
+**If the current branch is NOT `main`:** use it directly — go to step 3.
+
+**If the current branch IS `main`:**
+
+a. Read the commit subjects from the log above.
+
+b. Derive a branch name from the first (or most representative) commit subject:
+
+- Strip the Conventional Commits prefix (`fix:`, `feat(scope):`, etc.) and any leading punctuation.
+- Lower-case, replace spaces and special characters with `-`, truncate to 50 characters.
+- Prefix with the Conventional Commits type when present: `feat/`, `fix/`, `chore/`, etc.
+- Example: `feat(ci): add actionlint hook` → `feat/add-actionlint-hook`
+
+c. Create and push the branch:
+
+   ```bash
+   git checkout -b <derived-branch-name>
+   git push -u origin <derived-branch-name>
+   ```
+
+### 3. Collect the diff
+
+```bash
+git log --oneline origin/main..HEAD
+git diff origin/main...HEAD
+```
+
+### 4. Read the PR template
+
+Read `.github/PULL_REQUEST_TEMPLATE.md` verbatim — this is the skeleton to fill in.
+
+### 5. Derive the PR title
+
+The title **must** follow Conventional Commits format: `type(scope): subject`
+(imperative mood, no trailing period, ≤ 72 characters total).
+
+- If all commits share the same type and scope, use that type/scope directly.
+- If commits span multiple types, pick the dominant one (prefer `feat` > `fix` > others).
+- If commits span multiple scopes, omit the scope parenthetical.
+- The subject must be a concise imperative phrase summarising the PR, not a list of
+  commit subjects.
+- Examples: `feat(ci): add actionlint pre-commit hook`,
+  `fix(terraform): correct S3 bucket policy`
+
+### 6. Fill in the template
+
+Replace every `{{ placeholder }}` and populate every section:
+
+| Template section | What to write |
+|-----------------|---------------|
+| `## Description` | One concise paragraph: *what* changed and *why*. No implementation detail. |
+| `## Changes`    | Bulleted list of concrete changes (files, resources, modules). Name them. |
+| `## Testing`    | Check boxes that honestly apply; add a note if manual testing was done. |
+| `## Checklist`  | Check every box that is satisfied; leave unchecked anything not yet done. |
+
+### 7. Create and submit the PR
+
+Run `gh pr create` with the title and filled-in description:
+
+```bash
+gh pr create \
+  --base main \
+  --title "<PR title>" \
+  --body "$(cat <<'EOF'
+<filled PR description>
+EOF
+)"
+```
+
+After the command succeeds, output the PR URL returned by `gh pr create`.
+
+## Quality rules
+
+- Do **not** invent changes that are not visible in the diff.
+- Do **not** add extra sections beyond what the template defines.
+- Keep the Description to ≤ 3 sentences.
+- The Changes list must use plain Markdown bullets (`-`), not numbered lists.
+- Preserve every HTML comment (`<!-- … -->`) from the template; do not delete them.
+- Do **not** commit or amend any existing commits.
+- If `gh pr create` fails because the branch already has an open PR, report the existing
+  PR URL and stop — do not create a duplicate.
+
+## Example invocations
+
+```text
+/pr-description
+```
+
+Works from `main` (creates a branch) or from any feature branch.

--- a/.claude/skills/shell/SKILL.md
+++ b/.claude/skills/shell/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: shell
+description: Enforce the repo-standard structure for shell scripts (main() first, steps as functions, invocation at the bottom)
+user-invocable: true
+model: Haiku
+allowed-tools: Bash(mise exec -- uv run pre-commit run:*), Bash(*/mise exec -- uv run pre-commit run:*)
+---
+
+# Shell Script Structure
+
+## Purpose
+
+Every shell script created or modified in this repository must follow a consistent, top-down layout so that a reader can understand *what* the script does from `main()` alone, and drill into *how* each step works by reading the dedicated function below.
+
+## When to Use
+
+**ALWAYS** use this skill when:
+
+- Creating a new shell script (`.sh`, `.bash`) anywhere in the repo (e.g. `scripts/`, `.claude/skills/*/scripts/`, ad-hoc helpers).
+- Modifying an existing shell script — if it does not yet match this structure, refactor it into this shape as part of the change.
+- Reviewing AI-generated shell code before writing it to disk.
+
+## Required Structure
+
+Every script must be organised in this exact order:
+
+1. **Shebang** — `#!/usr/bin/env bash` (preferred) or `#!/bin/bash`.
+2. **Header comment block** — one-line purpose, usage, options, examples.
+3. **Strict mode** — `set -euo pipefail` (add `IFS=$'\n\t'` if word-splitting matters).
+4. **`main()` function** — declared *before* any other function.
+5. **Helper functions** — one per high-level step, declared *after* `main()`.
+6. **Invocation line** — `main "$@"` on the last line of the file.
+
+## Formatting
+
+Always read and respect `.editorconfig` at the repo root before writing or modifying a shell script. It is the source of truth for indentation, line endings, charset, and final-newline rules. `shellcheck` won't flag it, but it breaks `.editorconfig` consistency.
+
+### `main()` rules
+
+- Stays minimal: sets a few required global variables (or parses args) and calls helpers.
+- Reads like a human-language outline of the script: each line is a high-level step.
+- No inline business logic, no nested loops, no `case` blocks beyond simple arg parsing.
+- Helpers have verb-based, descriptive names (`validate_inputs`, `fetch_state`, `run_destroy`, `cleanup`).
+
+### Helper function rules
+
+- Declared *below* `main()`, in roughly the order they are called.
+- Each corresponds to one human-understandable step from `main()`.
+- Use `local` for every variable inside a function.
+- Return meaningful exit codes; let `set -e` propagate failures.
+
+## Template
+
+```bash
+#!/usr/bin/env bash
+#
+# <one-line purpose>
+#
+# Usage:
+#   ./script-name.sh [--flag VALUE] [ARG]
+#
+# Options:
+#   --flag VALUE   <description>
+#
+# Example:
+#   ./script-name.sh --flag foo bar
+#
+
+set -euo pipefail
+
+main() {
+  REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  TARGET="${1:-default}"
+
+  parse_args "$@"
+  validate_inputs
+  do_the_thing
+  cleanup
+}
+
+parse_args() {
+  # flag parsing here
+  :
+}
+
+validate_inputs() {
+  local dir="$REPO_ROOT/$TARGET"
+  [[ -d "$dir" ]] || { echo "ERROR: missing $dir" >&2; exit 1; }
+}
+
+do_the_thing() {
+  # core logic — one responsibility
+  :
+}
+
+cleanup() {
+  # tear down temp files, etc.
+  :
+}
+
+main "$@"
+```
+
+> Indentation above is 2 spaces per repo `.editorconfig`. Adjust if the target repo's `.editorconfig` says otherwise — `.editorconfig` always wins over this template.
+
+## Anti-patterns to reject
+
+- Top-level imperative code other than `set …`, constant assignments that `main()` genuinely cannot own, and the final `main "$@"` line.
+- `main()` defined at the bottom of the file (below helpers) — this repo requires `main()` on top.
+- A `main()` that contains the whole logic as one long sequence instead of delegating to named steps.
+- Helpers defined *above* `main()` — reader should hit the outline first.
+- Missing `main "$@"` invocation at the bottom.
+- Relying on function hoisting tricks or sourcing the script without `main` being explicitly invoked.
+
+## Quality checks
+
+After writing or modifying a shell script, run:
+
+```bash
+mise exec -- uv run pre-commit run --files path/to/script.sh
+```
+
+This triggers `shellcheck` (configured in `.pre-commit-config.yaml`) and fixes indentation/EOL per `.editorconfig`. Resolve every finding before finishing the task.
+
+## Rationale
+
+- **Readability** — `main()` at the top gives a reader the table of contents; they only drill into helpers they care about.
+- **Testability** — isolated helpers are easy to source and unit-test with `bats` or by calling them directly.
+- **Consistency** — matches the style already used in longer scripts in `scripts/` and mirrors the top-down layout of Python entry points in this codebase.

--- a/.claude/skills/terraform/SKILL.md
+++ b/.claude/skills/terraform/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: terraform
+description: Run the repo-pinned version of terraform via mise
+user-invocable: false
+model: Haiku
+allowed-tools: Bash(*/mise:*),Bash(mise:*)
+---
+
+# Terraform via mise
+
+## Purpose
+
+Run `terraform` using the version pinned by this repo's [.mise.toml](../../../.mise.toml). [mise](https://mise.jdx.dev) resolves the correct terraform binary per directory.
+
+## When to Use
+
+**ALWAYS** use this skill before running ANY `terraform` command (`init`, `plan`, `apply`, `destroy`, `fmt`, `validate`, etc.).
+
+## Step 1 — Locate `mise`
+
+Resolve `mise` once per session. Try these in order and stop at the first hit:
+
+1. `mise` already on `PATH` (use it as-is)
+2. `/opt/homebrew/bin/mise` — macOS Homebrew (Apple Silicon)
+3. `/usr/local/bin/mise` — macOS Homebrew (Intel) / common Linux install
+4. `/home/linuxbrew/.linuxbrew/bin/mise` — Linux Homebrew
+5. `$HOME/.local/bin/mise` — mise installer default
+
+If none resolve, tell the user mise is missing and suggest `brew install mise` (or <https://mise.jdx.dev/getting-started.html>).
+
+## Step 2 — Run terraform
+
+Prefix every terraform invocation with `<mise> exec --`. mise reads `.mise.toml` from the current working directory and injects the pinned tool's `bin/` into `PATH` for the wrapped command.
+
+```bash
+mise exec -- terraform init
+mise exec -- terraform plan
+mise exec -- terraform apply
+mise exec -- terraform fmt -check
+```
+
+Substitute the full path from Step 1 if `mise` is not on `PATH` (e.g. `/opt/homebrew/bin/mise exec -- terraform init`).
+
+## Working Directory
+
+`mise exec` reads `.mise.toml` relative to CWD. Terraform code for this project lives in `src/terraform/` — `cd` into it first (or pass `--chdir`) so Terraform sees the right configuration, while mise still picks up the repo-root `.mise.toml`.
+
+## Error Handling
+
+- **`mise` not found in any candidate path** → install via `brew install mise`, or see <https://mise.jdx.dev/getting-started.html>.
+- **`terraform: no such tool installed`** → run `mise install` from the repo root to install tools declared in `.mise.toml`.
+- **Version mismatch with `.mise.toml`** → run `mise install terraform` to sync.

--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -1,0 +1,21 @@
+version: "0.2"
+language: en,en-GB
+
+import:
+  - "${userHome}/.cspell.config.yaml"
+
+dictionaryDefinitions:
+  - name: project-words
+    path: ./.cspell/project-words.txt
+    addWords: true
+
+dictionaries:
+  - aws
+  - project-words
+  - terraform
+
+useGitignore: true
+
+ignorePaths:
+  - "**/node_modules/**"
+  - "**/dist/**"

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -1,0 +1,14 @@
+# Local project dictionary words
+# One word per line
+
+hostnames
+linuxbrew
+
+# Python words
+pymarkdown
+pyml
+
+# Terraform words
+allfiles
+tfenv
+tflock

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,92 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers
+# working on the same project across various editors and IDEs.
+# https://editorconfig.org
+
+root = true
+
+# All files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown files
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+max_line_length = off
+
+# Terraform files
+[*.{tf,tfvars,hcl,tftpl,tfvars.example}]
+indent_style = space
+indent_size = 2
+
+# JSON files
+[*.json]
+indent_style = space
+indent_size = 2
+
+# YAML files
+[*.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+# TOML files
+[*.toml]
+indent_style = space
+indent_size = 2
+
+# Python files
+[*.py]
+indent_style = space
+indent_size = 4
+max_line_length = 88
+
+# Shell script files
+[*.{sh,bash,zsh}]
+indent_style = space
+indent_size = 2
+
+# Makefiles — require literal tabs for recipe lines
+[{Makefile,makefile,GNUmakefile,*.mk}]
+indent_style = tab
+
+# Docker files
+[Dockerfile*]
+indent_style = space
+indent_size = 2
+
+# Docker compose files
+[docker-compose.{yaml,yml}]
+indent_style = space
+indent_size = 2
+
+# Web files
+[*.{html,js,css}]
+indent_style = space
+indent_size = 2
+
+# Plain text files
+[*.txt]
+indent_style = space
+indent_size = 2
+
+# .gitignore and other dot files
+[.{gitignore,gitattributes,editorconfig}]
+indent_style = space
+indent_size = 2
+
+# pymarkdown config (TOML syntax)
+[.pymarkdown]
+indent_style = space
+indent_size = 2
+
+# yamllint config (YAML syntax)
+[.yamllint]
+indent_style = space
+indent_size = 2
+
+# Lockfiles (uv.lock, *.lock) — managed by tooling, keep deterministic indentation
+[*.lock]
+indent_style = space
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Set default behavior to automatically normalize line endings
+* text=auto eol=lf
+
+# Terraform
+*.tf               text eol=lf
+*.tfvars           text eol=lf
+*.tfvars.example   text eol=lf
+*.hcl              text eol=lf
+*.tftpl            text eol=lf
+
+# Shell scripts
+*.sh        text eol=lf
+
+# Build / container
+Makefile    text eol=lf
+*.mk        text eol=lf
+Dockerfile* text eol=lf
+
+# Lockfiles
+*.lock      text eol=lf
+
+# Python
+*.py        text eol=lf diff=python
+
+# Web
+*.html      text eol=lf diff=html
+*.js        text eol=lf
+*.css       text eol=lf
+
+# Data / config
+*.json      text eol=lf
+*.yaml      text eol=lf
+*.yml       text eol=lf
+*.toml      text eol=lf
+*.txt       text eol=lf
+
+# Docs
+*.md        text eol=lf
+*.markdown  text eol=lf
+
+# Tool config dotfiles
+.pymarkdown text eol=lf
+.yamllint   text eol=lf
+
+# Binary assets
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.gif       binary
+*.ico       binary
+*.svg       text eol=lf

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- pyml disable md041 -->
+## Description
+
+{{ description }}
+
+## Changes
+
+{{ changes }}
+
+## Testing
+
+<!-- Describe how the changes were tested (unit tests, manual, etc.). -->
+
+- [ ] Unit tests added / updated
+- [ ] Manually verified
+
+## Checklist
+
+- [ ] No secrets or credentials included
+- [ ] `make lint` passes locally

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# AI Instructions - GitHub Copilot
+
+This repository keeps AI coding instructions in a single source of truth:
+
+- [docs/ai-instructions.md](../docs/ai-instructions.md)
+
+GitHub Copilot: follow the linked instructions as if they were in this file.
+
+Shared skills are defined in `.claude/skills/`. Use those skills and avoid creating duplicated skill instructions under `.github/skills/`.
+
+## Command execution permissions
+
+When evaluating or executing shell commands, GitHub Copilot should consult the workspace permissions declared in `.claude/settings.json` and follow them exactly. In particular:
+
+- Only allow commands that match patterns listed under `permissions.allow` in `.claude/settings.json`.
+- Never execute commands that match patterns listed under `permissions.deny` in `.claude/settings.json`.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "terraform"
+    directory: "/src/terraform"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "terraform"
+    directory: "/src/terraform/bootstrap"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "addLabels": [
+    "ci"
+  ],
+  "schedule": [
+    "before 6am on monday"
+  ],
+  "semanticCommits": "enabled",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "enabledManagers": [
+    "pep621"
+  ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "commitMessageAction": "update lock file",
+    "schedule": [
+      "before 6am on monday"
+    ]
+  }
+}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,51 @@
+name: "On PR & push: Conventional Commits"
+# cspell:ignore amannn commitlint wagoid
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce Conventional Commit format in PR title
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+
+  commit-messages:
+    name: Validate commit messages
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Enforce Conventional Commit format in commit messages
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          failOnWarnings: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,63 @@
+name: "On PR & push: Lint project"
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get changed files
+        uses: tj-actions/changed-files@v47
+        id: changed
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          files_yaml: |
+            allfiles:
+              - '**/*'
+
+      - name: Set up Mise toolchain
+        uses: jdx/mise-action@v4
+        with:
+          version: 2026.3.9
+
+      - name: Install lint dependencies
+        # Install pyproject dependencies using the uv version managed by Mise.
+        run: mise exec -- uv sync --group lint --frozen
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: precommit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            precommit-${{ runner.os }}-
+
+      # Configuration file for pre-commit: .pre-commit-config.yaml
+      # Linter configurations:
+      # - Configuration file for Markdown: .pymarkdown
+      # - Configuration file for YAML: .yamllint
+      - name: Run pre-commit on changed files
+        if: steps.changed.outputs.allfiles_any_changed == 'true'
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed.outputs.allfiles_all_changed_files }}
+        run: |-
+          # shellcheck disable=SC2086
+          mise exec -- uv run --no-sync \
+            pre-commit run --files ${ALL_CHANGED_FILES} --show-diff-on-failure

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Terraform
+.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Sensitive variable files
+*.auto.tfvars
+terraform.tfvars
+
+# Python / uv
+.venv/
+
+# Claude Code
+.claude/settings.local.json
+
+# OS
+.DS_Store

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,4 @@
+[tools]
+pre-commit = "latest"
+terraform = "prefix:1.14"
+uv = "latest"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+repos:
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/jackdewinter/pymarkdown
+    rev: v0.9.36
+    hooks:
+      - id: pymarkdown
+        args:
+          - --config
+          - .pymarkdown
+          - scan
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.105.0
+    hooks:
+      - id: terraform_fmt
+
+  - repo: local
+    hooks:
+      - id: terraform-validate-root
+        name: terraform validate (root module)
+        entry: scripts/terraform-validate-module.sh src/terraform
+        language: script
+        files: ^src/terraform/.*\.(tf|tfvars)$
+        exclude: ^src/terraform/bootstrap/
+        pass_filenames: false
+
+      - id: terraform-validate-bootstrap
+        name: terraform validate (bootstrap module)
+        entry: scripts/terraform-validate-module.sh src/terraform/bootstrap
+        language: script
+        files: ^src/terraform/bootstrap/.*\.(tf|tfvars)$
+        pass_filenames: false

--- a/.pymarkdown
+++ b/.pymarkdown
@@ -1,0 +1,12 @@
+{
+  "extensions": {
+    "front-matter": {
+      "enabled": true
+    }
+  },
+  "plugins": {
+    "md013": {
+      "enabled": false
+    }
+  }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+  "recommendations": [
+    "bierner.markdown-mermaid",
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+    "editorconfig.editorconfig",
+    "hashicorp.terraform",
+    "shd101wyy.markdown-preview-enhanced",
+    "streetsidesoftware.code-spell-checker-cspell-bundled-dictionaries",
+    "tylerharris.terraform-link-docs",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "workbench.colorCustomizations": {
+        "activityBar.background": "#1f2045",
+        "titleBar.activeBackground": "#2e2c60",
+        "titleBar.activeForeground": "#FCF9FC"
+    },
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "**/.git disable exclusion of .git": true,
+        ".git": true
+    },
+    "explorerExclude.backup": {},
+    "hide-files.files": [],
+    "makefile.configureOnOpen": false,
+    "json.schemaDownload.trustedDomains": {
+        "https://docs.renovatebot.com": true
+    }
+}

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+---
+
+extends: default
+
+rules:
+    document-start: disable
+    line-length: disable
+    truthy: disable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,24 @@
+<!-- pyml disable md041 -->
+
+@docs/ai-instructions.md
+
+---
+
+## Claude Code — Additional Instructions
+
+The shared instructions above apply to all AI tools. The notes below are Claude Code-specific.
+
+### Memory & context
+
+- Project memory is stored in `~/.claude/projects/…/memory/`. Update it when discovering
+  new stable patterns.
+- For code-change behavior and repository conventions, follow `docs/ai-instructions.md`.
+
+### Tool preferences
+
+- Use the built-in Read/Edit/Glob/Grep tools over shell equivalents (cat, grep, find).
+
+### Commits & PRs
+
+- Do not commit or push unless explicitly asked.
+- For commit message format, follow `docs/ai-instructions.md` (Conventional Commits).

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+.DEFAULT_GOAL := help
+
+# Run commands through the mise-managed uv-managed virtualenv.
+UV  := mise exec -- uv
+RUN := $(UV) run
+
+# ── Help ──────────────────────────────────────────────────────────────────────
+
+.PHONY: help
+help: ## Show available make targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN {FS = ":.*?## "}; {printf "  %-20s %s\n", $$1, $$2}'
+
+# ── Linting ───────────────────────────────────────────────────────────────────
+
+.PHONY: lint
+lint: ## Run all linters via pre-commit (yamllint, shellcheck, actionlint, terraform, …)
+	$(RUN) pre-commit run --all-files
+
+# ── Install ───────────────────────────────────────────────────────────────────
+
+.PHONY: install
+install: ## Install Python dev dependencies via uv
+	$(UV) sync --frozen
+
+# ── Update UV lock file ───────────────────────────────────────────────────────
+
+.PHONY: lock
+lock: ## Regenerate uv.lock from pyproject.toml
+	$(UV) lock

--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# AWS Infrastructure Template
+
+Polyglot project template where Terraform code lives under `src/terraform/` and the
+repo root is reserved for language-agnostic tooling (CI, linters, editor config, AI
+instructions, docs).
+
+The example Terraform defines a small AWS stack (a VPC with public/private subnets
+and a single S3 bucket) intended as a starting point — replace the modules with
+your own resources.
+
+> **Developers**: review [docs/ai-instructions.md](docs/ai-instructions.md) for project structure, coding conventions, and linting rules.
+
+## Architecture
+
+Two-stage Terraform deployment, both under `src/terraform/`:
+
+1. **Bootstrap** (`src/terraform/bootstrap/`) — applied once; provisions the S3
+   state bucket, DynamoDB lock table, and a bucket for backing up bootstrap's
+   own local-backend state.
+2. **Root module** (`src/terraform/`) — calls `modules/networking` and
+   `modules/storage`; uses the S3 backend produced by bootstrap.
+
+```mermaid
+flowchart TD
+    User([Operator])
+        User -->|"1. terraform apply (once)"| Bootstrap["src/terraform/bootstrap"]
+        Bootstrap --> StateBucket[("S3 state bucket")]
+        Bootstrap --> LockTable[("DynamoDB lock table")]
+        Bootstrap --> BackupBucket[("S3 bootstrap-state backup")]
+
+        User -->|"2. terraform apply (repeated)"| Root["src/terraform (root module)"]
+        Root -->|state| StateBucket
+        Root -->|lock| LockTable
+        Root --> Networking["modules/networking (VPC)"]
+        Root --> Storage["modules/storage (S3 bucket)"]
+```
+
+## Development Setup
+
+The repo pins tool versions via [mise](https://mise.jdx.dev) and manages Python dev
+dependencies (currently just `pre-commit`) with [uv](https://docs.astral.sh/uv/).
+Common dev tasks are wrapped in the [Makefile](Makefile).
+
+```bash
+brew install mise                             # macOS · one-time, bootstraps uv + terraform
+make lock                                     # generate uv.lock from pyproject.toml (first time)
+make install                                  # uv sync --frozen — create .venv from uv.lock
+mise exec -- uv run pre-commit install        # enable git hooks (once per clone)
+```
+
+Other handy targets:
+
+```bash
+make help      # list all targets
+make lint      # run all pre-commit hooks against the whole repo
+make lock      # regenerate uv.lock after editing pyproject.toml
+```
+
+## Deploy
+
+```bash
+export AWS_PROFILE=<your-profile>
+
+# 1. One-time: provision the state backend — see
+#    src/terraform/bootstrap/README.md for the full guide (includes the
+#    backend.tf swap that must happen between the two stages).
+cd src/terraform/bootstrap
+mise exec -- terraform init
+mise exec -- terraform apply
+
+# 2. Root module — applied repeatedly
+cd ..
+mise exec -- terraform init      # (add -migrate-state the first time after swapping to the S3 backend)
+mise exec -- terraform apply
+
+# Teardown (root only — leaves bootstrap/state backend intact)
+mise exec -- terraform destroy
+```
+
+See [docs/ai-instructions.md](docs/ai-instructions.md) for project structure and
+conventions, [src/terraform/bootstrap/README.md](src/terraform/bootstrap/README.md)
+for the full bootstrap walkthrough, and `.claude/skills/` for AI helper skills
+(AWS auth, Terraform via mise, PR description generation, shell script structure).
+
+## Using this as a template
+
+1. Copy the directory contents into a fresh git repo.
+2. Replace placeholder values:
+   - Project name and description in [pyproject.toml](pyproject.toml) and this
+     [README.md](README.md).
+   - AWS profile name in [src/terraform/providers.tf](src/terraform/providers.tf) if
+     you do not want to rely on `AWS_PROFILE`.
+   - SSO constants in [.claude/scripts/aws-sso-credentials.sh](.claude/scripts/aws-sso-credentials.sh)
+     if you plan to use it.
+3. Adjust the two example modules (`networking`, `storage`) to match the
+   resources you actually need.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -1,0 +1,271 @@
+<!-- pyml disable md025 -->
+# AI Instructions
+
+> **Single source of truth for AI coding instructions.**
+>
+> - **Claude Code** reads this via `CLAUDE.md` (`@docs/ai-instructions.md`).
+> - **GitHub Copilot** reads `.github/copilot-instructions.md`, which links to this file.
+> - **Edit only this file.** CI verifies Copilot instructions reference it.
+
+---
+
+# AWS Infrastructure Template
+
+Polyglot project template. Terraform code lives under `src/terraform/`; the repo
+root is reserved for language-agnostic tooling (CI, linters, editor config, AI
+instructions, docs).
+
+## Architecture
+
+Two-stage Terraform deployment, both under `src/terraform/`:
+
+1. **`src/terraform/bootstrap/`** (persistent, apply once) — S3 state-backend
+   bucket, S3 state-backup bucket, DynamoDB lock table. Uses the local backend
+   for its own state.
+2. **`src/terraform/`** (root module, applied repeatedly) — wires the provider
+   and calls the child modules below. Uses the S3 backend created by bootstrap
+   (after swapping `backend "local" {}` for an `backend "s3" {}` block in
+   [../src/terraform/backend.tf](../src/terraform/backend.tf)).
+
+Root-module child modules:
+
+- **`modules/networking/`** — VPC with public and private subnets.
+- **`modules/storage/`** — a single S3 bucket with public-access block, TLS-only policy,
+  and default encryption.
+
+## Tech Stack
+
+| Tool             | Version / Notes                                                   |
+| ---------------- | ----------------------------------------------------------------- |
+| Primary language | Terraform (HCL)                                                   |
+| Task runner      | `make` (see [Makefile](../Makefile))                              |
+| Python toolchain | [`uv`](https://docs.astral.sh/uv/) — dev deps in `pyproject.toml` |
+| Tool versioning  | [`mise`](https://mise.jdx.dev) — pins `terraform`, `uv`, etc.     |
+| CI               | GitHub Actions                                                    |
+
+## Workflow
+
+### Deploy bootstrap resources (first time only)
+
+See [@src/terraform/bootstrap/README.md](../src/terraform/bootstrap/README.md) for the full guide.
+TL;DR:
+
+```bash
+cd src/terraform/bootstrap
+cp terraform.tfvars.example terraform.tfvars   # edit values
+mise exec -- terraform init
+mise exec -- terraform apply
+
+# Back up the local bootstrap state to the backup bucket
+mise exec -- terraform output -json bootstrap_state_backup_commands | jq -r '.upload' | bash
+```
+
+Then edit [../src/terraform/backend.tf](../src/terraform/backend.tf), replacing
+the `backend "local" {}` stub with the `backend "s3" {...}` block printed by
+`terraform output -json backend_config`.
+
+### Deploy resources from the root Terraform module
+
+```bash
+cd src/terraform
+mise exec -- terraform init -migrate-state   # first time after backend swap
+mise exec -- terraform apply
+```
+
+To tear everything down:
+
+```bash
+cd src/terraform
+mise exec -- terraform destroy
+```
+
+## Make targets
+
+The [Makefile](../Makefile) wraps the most common dev tasks. All targets execute through
+`mise exec -- uv` so they use the mise-pinned `uv` and the uv-managed virtualenv.
+
+```bash
+make help        # list all targets
+make install     # uv sync --frozen  — install dev deps from uv.lock
+make lock        # uv lock           — regenerate uv.lock after editing pyproject.toml
+make lint        # uv run pre-commit run --all-files
+```
+
+Typical bootstrap in a fresh clone:
+
+```bash
+make lock               # generate uv.lock from pyproject.toml (first time only)
+make install            # creates .venv and installs pre-commit
+mise exec -- uv run pre-commit install   # enable git hooks
+```
+
+After editing `pyproject.toml` (adding/removing/bumping a Python dev dep):
+
+```bash
+make lock && make install   # regenerate uv.lock and re-sync .venv
+```
+
+`make install` uses `--frozen`, so it will fail fast if `uv.lock` is missing or
+out of sync with `pyproject.toml` — this is intentional and enforces reproducible installs.
+
+## AWS Authentication
+
+**IMPORTANT**: Always use the `aws` skill to configure authentication before running AWS CLI commands or Terraform operations.
+
+Set `AWS_PROFILE` to the profile you want the project to use:
+
+```bash
+export AWS_PROFILE=<your-profile>
+aws sts get-caller-identity
+```
+
+See [@.claude/skills/aws/SKILL.md](.claude/skills/aws/SKILL.md) for complete authentication documentation including setup helpers, error handling, and alternative methods.
+
+## Terraform Executable Location
+
+**IMPORTANT**: Before running any Terraform commands, always use the terraform skill. The repo pins terraform via [.mise.toml](../.mise.toml); the skill runs that pinned version through Homebrew-installed [mise](https://mise.jdx.dev).
+
+Quick start:
+
+```bash
+cd src/terraform
+mise exec -- terraform init
+mise exec -- terraform plan
+mise exec -- terraform apply
+```
+
+See [@.claude/skills/terraform/SKILL.md](.claude/skills/terraform/SKILL.md) for details and error handling.
+
+## Terraform Commands
+
+```bash
+terraform init          # Initialize providers and modules
+terraform fmt           # Format all .tf files
+terraform fmt -check    # Check formatting without modifying
+terraform validate      # Validate configuration syntax
+terraform plan          # Preview changes
+terraform apply         # Apply changes (requires confirmation)
+terraform destroy       # Tear down all resources (requires confirmation)
+```
+
+## Project Structure
+
+```text
+aws-infra-template/
+├── Makefile                         # Dev task runner (install, lock, lint)
+├── pyproject.toml                   # Python dev dependency manifest (uv)
+├── uv.lock                          # uv lockfile — committed for reproducibility
+├── .mise.toml                       # Pinned tool versions (terraform, uv, …)
+├── .pre-commit-config.yaml          # Pre-commit hook definitions
+├── README.md                        # Project documentation
+├── CLAUDE.md                        # Claude Code instructions
+├── docs/
+│   └── ai-instructions.md           # AI coding instructions (source of truth)
+├── scripts/
+│   └── terraform-validate-module.sh # Pre-commit helper: validate one Terraform module
+└── src/
+    └── terraform/
+        ├── main.tf                      # Root module: provider wiring + module calls
+        ├── versions.tf                  # Terraform version and provider requirements
+        ├── providers.tf                 # Provider configurations (aws)
+        ├── variables.tf                 # Root variables
+        ├── outputs.tf                   # Root outputs
+        ├── backend.tf                   # Backend configuration (local by default; swap to s3 after bootstrap)
+        ├── locals.tf                    # name_prefix, common_tags
+        ├── data.tf                      # caller_identity, region
+        ├── terraform.tfvars.example     # Example variable values
+        ├── bootstrap/
+        │   ├── main.tf                  # Provider config (local backend)
+        │   ├── variables.tf             # region, project_name, environment, state_key
+        │   ├── outputs.tf               # bucket, table, backend_config, backup commands
+        │   ├── locals.tf                # name_prefix, tags
+        │   ├── state.tf                 # S3 state bucket + DynamoDB lock table
+        │   ├── bootstrap-state-bucket.tf# S3 bucket for bootstrap state backup
+        │   ├── terraform.tfvars.example # Example variable values
+        │   └── README.md                # Bootstrap deployment instructions
+        └── modules/
+            ├── networking/              # VPC, subnets, IGW, route tables
+            └── storage/                 # S3 bucket with TLS-only policy and encryption
+```
+
+## Code Style & Conventions
+
+### Commit messages
+
+Use Conventional Commits format: `type(scope): subject` — imperative mood, no trailing period.
+Example: `fix(ci): handle missing env variable`
+
+### Terraform
+
+- **Variable naming**: snake_case, descriptive names with `description` and `type` always set
+- **File organization**: group related resources into dedicated modules under `src/terraform/modules/`; within a module use focused files (`main.tf`, `variables.tf`, `outputs.tf`, `README.md`)
+- **Formatting**: always run `terraform fmt` before finishing any change to `.tf` files
+- **Tagging**: tag all resources via `common_tags` from `src/terraform/locals.tf` (root) or `src/terraform/bootstrap/locals.tf` (bootstrap)
+- **Security groups**: use standalone `aws_vpc_security_group_ingress_rule` / `aws_vpc_security_group_egress_rule` resources (provider 6.x best practice — avoids rule conflicts)
+
+### Pre-commit
+
+The project uses [pre-commit](https://pre-commit.com) to enforce formatting and linting.
+`pre-commit` itself is installed as a Python dev dependency via `uv` — see the
+[Make targets](#make-targets) section for the install flow. Configured hooks:
+
+| Hook                           | Scope                                                                |
+| ------------------------------ | -------------------------------------------------------------------- |
+| `terraform_fmt`                | All `.tf` and `.tfvars` files                                        |
+| `terraform-validate-root`      | Root Terraform module under `src/terraform/` (excludes `bootstrap/`) |
+| `terraform-validate-bootstrap` | `src/terraform/bootstrap/` module                                    |
+| `yamllint`                     | YAML files                                                           |
+| `pymarkdown`                   | Markdown files                                                       |
+| `shellcheck`                   | Shell scripts                                                        |
+| `actionlint`                   | GitHub Actions workflows                                             |
+
+Both `terraform-validate-*` hooks call [scripts/terraform-validate-module.sh](../scripts/terraform-validate-module.sh),
+which runs `terraform validate` through the repo-pinned `terraform` (via `mise exec`)
+against a single module. Root and bootstrap are validated independently — changes
+in one do not trigger validation of the other.
+
+Enable in a fresh clone (after `make install`):
+
+```bash
+mise exec -- uv run pre-commit install
+```
+
+Run against specific files (faster than `--all-files`):
+
+```bash
+mise exec -- uv run pre-commit run --files path/to/file1 path/to/file2
+```
+
+Or simply `make lint` to run every hook against every file.
+
+### Formatting (Source of Truth)
+
+- Follow `.editorconfig` in the repository root for formatting rules.
+- This includes charset, line endings, indentation, trailing whitespace, final newline,
+  and file-type-specific overrides.
+- If a formatting rule here ever conflicts with `.editorconfig`, `.editorconfig` wins.
+- When generating or formatting code, consult the linter configuration files:
+  - **Python** — `pyproject.toml` (`[tool.ruff]` and `[tool.ruff.lint]` sections)
+  - **YAML** — `.yamllint`
+  - **Markdown** — `.pymarkdown`
+
+### Adding a new file type
+
+When introducing a file type that is not yet covered, update **both** config files:
+
+1. **`.editorconfig`** — add a glob section with the appropriate overrides.
+2. **`.gitattributes`** — add an entry with `text eol=lf` (or `eol=crlf` for Windows-only
+   files, or `binary` for binary assets). Add `diff=<language>` when git has a built-in
+   driver for that language.
+
+Do this as part of the same change that adds the first file of that type.
+
+## AI Behaviour Guidelines
+
+- **Minimal changes**: prefer targeted edits over large refactors unless explicitly asked
+- **Follow existing patterns**: read the surrounding code before suggesting changes
+- **Pre-commit validation**: after modifying any source file, run `mise exec -- uv run pre-commit run --files <changed files>` (or `make lint` for a full sweep) and fix every reported issue before finishing — do not skip or bypass hooks
+- **Dev deps**: when adding/removing a Python dev dependency, prefer `mise exec -- uv add --group <group> <pkg>` / `uv remove <pkg>`. If editing `pyproject.toml` by hand, run `make lock` followed by `make install` and commit `pyproject.toml` and `uv.lock` together
+- **No secrets**: never generate tokens, passwords, or credentials — use GitHub Actions secrets
+- **Skills source of truth**: keep shared skills only in `.claude/skills/`; GitHub Copilot must use these shared skills and must not duplicate skill definitions under `.github/skills/`
+- **Commit messages**: use Conventional Commits format `type(scope): subject` (e.g. `fix(ci): handle missing env variable`), with an imperative subject and no trailing period

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+# aws-infra-template's Python configuration.
+# This file exists only to declare dev dependencies; the project itself
+# is primarily Terraform, not a Python package.
+
+# cspell:words testpaths
+
+[project]
+name = "aws-infra-template"
+version = "0.1.0"
+description = "Polyglot project template with Terraform in src/terraform"
+requires-python = ">=3.14"
+dependencies = [
+  # No runtime dependencies, but dev dependencies are declared below.
+]
+
+[tool.uv]
+# This project has no installable Python package — uv should only manage
+# the dev dependencies declared below.
+package = false
+
+[dependency-groups]
+lint = ["pre-commit"]
+test = [
+  # Test dependencies would go here, e.g. "pytest" or "mypy".
+]
+dev = [{ include-group = "lint" }, { include-group = "test" }]

--- a/scripts/terraform-validate-module.sh
+++ b/scripts/terraform-validate-module.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Validate a single Terraform module.
+#
+# Usage:
+#   ./terraform-validate-module.sh [TARGET_DIR]
+#
+# Arguments:
+#   TARGET_DIR   Directory to validate, relative to repo root (default: src/terraform)
+#
+# Example:
+#   ./terraform-validate-module.sh src/terraform
+#
+
+set -euo pipefail
+
+main() {
+  local repo_root target_dir mise_bin
+
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  target_dir="$(resolve_target_dir "$repo_root" "${1:-src/terraform}")"
+  mise_bin="$(resolve_mise)"
+  run_validate "$target_dir" "$mise_bin"
+}
+
+resolve_target_dir() {
+  local repo_root="$1" target="$2"
+  local full_path="$repo_root/$target"
+
+  if [[ ! -d "$full_path" ]]; then
+    echo "ERROR: target directory not found: $full_path" >&2
+    exit 1
+  fi
+
+  echo "$full_path"
+}
+
+resolve_mise() {
+  if command -v mise >/dev/null 2>&1; then
+    echo "mise"
+    return
+  fi
+
+  local candidate
+  for candidate in \
+    /opt/homebrew/bin/mise \
+    /usr/local/bin/mise \
+    /home/linuxbrew/.linuxbrew/bin/mise \
+    "$HOME/.local/bin/mise"; do
+    if [[ -x "$candidate" ]]; then
+      echo "$candidate"
+      return
+    fi
+  done
+
+  echo "ERROR: mise not found. Install via 'brew install mise' or see https://mise.jdx.dev/getting-started.html" >&2
+  exit 1
+}
+
+run_validate() {
+  local target_dir="$1" mise_bin="$2"
+
+  cd "$target_dir"
+  "$mise_bin" exec -- terraform init -backend=false -input=false -no-color >/dev/null
+  exec "$mise_bin" exec -- terraform validate -no-color
+}
+
+main "$@"

--- a/src/terraform/backend.tf
+++ b/src/terraform/backend.tf
@@ -1,0 +1,6 @@
+terraform {
+  # Default to the local backend so the template works out-of-the-box.
+  # Swap for `backend "s3" { ... }` (or another remote backend) when adopting
+  # this template for a real project.
+  backend "local" {}
+}

--- a/src/terraform/bootstrap/README.md
+++ b/src/terraform/bootstrap/README.md
@@ -1,0 +1,177 @@
+# Bootstrap Terraform Infrastructure
+
+Persistent Terraform state backend for this project. Apply once; after the
+initial apply, the root module in [../](..) uses the S3 bucket and DynamoDB
+table created here as its backend.
+
+## What this module creates
+
+- **S3 bucket** (`<project>-<env>-tfstate-<account-id>`) — stores the root-module
+  state file. Versioned, KMS-encrypted, public access blocked.
+- **DynamoDB table** (`<project>-<env>-tflock`) — lock table used by the S3
+  backend to prevent concurrent writes.
+- **S3 bucket** (`<project>-<env>-bootstrap-tfstate-<account-id>`) — backup
+  target for *this module's* own state file (bootstrap uses the local backend;
+  see "State management" below).
+
+## Prerequisites
+
+- AWS CLI configured with appropriate credentials
+- `mise` and `uv` bootstrapped (see repo root [README.md](../../../README.md))
+- Terraform pinned via [../../../.mise.toml](../../../.mise.toml)
+
+## Step 1 — Configure bootstrap variables
+
+```bash
+cd src/terraform/bootstrap
+cp terraform.tfvars.example terraform.tfvars
+```
+
+Edit `terraform.tfvars` with your values:
+
+```hcl
+aws_region   = "eu-central-1"
+environment  = "dev"
+project_name = "aws-infra-template"
+state_key    = "root/terraform.tfstate"
+```
+
+## Step 2 — Initialize and apply bootstrap
+
+```bash
+mise exec -- terraform init
+mise exec -- terraform plan
+mise exec -- terraform apply
+```
+
+## Step 3 — Back up bootstrap state to S3
+
+Bootstrap uses the **local** backend, so `terraform.tfstate` lives on your
+machine. Back it up to the backup bucket after each apply:
+
+```bash
+# Get the upload command from outputs
+mise exec -- terraform output -json bootstrap_state_backup_commands | jq -r '.upload'
+
+# Or run it directly (substitute account ID)
+aws s3 cp terraform.tfstate \
+  s3://aws-infra-template-dev-bootstrap-tfstate-<account-id>/terraform.tfstate
+```
+
+## Step 4 — Capture backend configuration for the root module
+
+```bash
+mise exec -- terraform output -json backend_config
+```
+
+Example output:
+
+```json
+{
+  "bucket": "aws-infra-template-dev-tfstate-123456789012",
+  "dynamodb_table": "aws-infra-template-dev-tflock",
+  "encrypt": true,
+  "key": "root/terraform.tfstate",
+  "region": "eu-central-1"
+}
+```
+
+## Step 5 — Configure the root module's backend
+
+Edit [../backend.tf](../backend.tf) and replace the `backend "local" {}`
+stub with an S3 backend using the values from Step 4:
+
+```hcl
+terraform {
+  backend "s3" {
+    bucket         = "aws-infra-template-dev-tfstate-123456789012"
+    key            = "root/terraform.tfstate"
+    region         = "eu-central-1"
+    dynamodb_table = "aws-infra-template-dev-tflock"
+    encrypt        = true
+  }
+}
+```
+
+Then re-initialize the root module:
+
+```bash
+cd ..
+mise exec -- terraform init -migrate-state
+```
+
+## State management summary
+
+### Bootstrap state (local backend)
+
+- **Location**: `src/terraform/bootstrap/terraform.tfstate` (gitignored)
+- **Backup**: S3 bucket created by this module
+- **Managed**: Manually, rarely changes
+- **Purpose**: Persistent infrastructure (state backend for everything else)
+
+### Root-module state (S3 backend)
+
+- **Location**: S3 bucket created by this module
+- **Locking**: DynamoDB table created by this module
+- **Managed**: Automatically by Terraform
+
+## Restoring bootstrap state from backup
+
+If you lose the local `terraform.tfstate` but the resources still exist:
+
+```bash
+cd src/terraform/bootstrap
+BUCKET="aws-infra-template-dev-bootstrap-tfstate-<account-id>"
+aws s3 cp "s3://${BUCKET}/terraform.tfstate" terraform.tfstate
+mise exec -- terraform show
+```
+
+## Destroying bootstrap
+
+> **Warning**: this destroys the state backend. Destroy the root module first,
+> then clear its state from the S3 bucket, then destroy bootstrap.
+
+```bash
+# 1. Destroy the root module
+cd src/terraform
+mise exec -- terraform destroy
+
+# 2. Empty the state bucket (required — it has versioning)
+aws s3 rm "s3://$(cd bootstrap && mise exec -- terraform output -raw state_bucket_name)" --recursive
+
+# 3. Destroy bootstrap (will fail while `prevent_destroy = true` — remove
+#    those lifecycle blocks in state.tf and bootstrap-state-bucket.tf first)
+cd bootstrap
+mise exec -- terraform destroy
+```
+
+## Troubleshooting
+
+### State locking issues
+
+```bash
+# List locks (replace <table> with dynamodb_table_name output)
+aws dynamodb scan --table-name <table>
+
+# Force-unlock using the Lock ID from the error message
+mise exec -- terraform force-unlock <lock-id>
+```
+
+### Bootstrap state out of sync
+
+Two recovery options:
+
+1. **Restore from S3 backup** — see "Restoring bootstrap state" above.
+2. **Import resources manually**:
+
+   ```bash
+   mise exec -- terraform import aws_s3_bucket.terraform_state <state-bucket-name>
+   mise exec -- terraform import aws_s3_bucket.bootstrap_state <backup-bucket-name>
+   mise exec -- terraform import aws_dynamodb_table.terraform_locks <lock-table-name>
+   ```
+
+## Security notes
+
+- `terraform.tfstate` contains resource IDs and config — never commit it
+  (already covered by the repo-root [.gitignore](../../../.gitignore)).
+- Both S3 buckets block all public access and enable encryption + versioning.

--- a/src/terraform/bootstrap/bootstrap-state-bucket.tf
+++ b/src/terraform/bootstrap/bootstrap-state-bucket.tf
@@ -1,0 +1,62 @@
+################################################################################
+# S3 Bucket for Bootstrap State Backup
+#
+# Bootstrap uses the local backend, so `terraform.tfstate` lives on the
+# operator's machine. This bucket exists as a backup target — upload the
+# file here after each `terraform apply` so it can be restored on another
+# machine (see README.md).
+################################################################################
+
+resource "aws_s3_bucket" "bootstrap_state" {
+  bucket = "${local.name_prefix}-bootstrap-tfstate-${local.account_id}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name    = "${local.name_prefix}-bootstrap-tfstate"
+    Purpose = "Backup storage for bootstrap terraform.tfstate"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "bootstrap_state" {
+  bucket = aws_s3_bucket.bootstrap_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bootstrap_state" {
+  bucket = aws_s3_bucket.bootstrap_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "bootstrap_state" {
+  bucket = aws_s3_bucket.bootstrap_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "bootstrap_state" {
+  bucket = aws_s3_bucket.bootstrap_state.id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}

--- a/src/terraform/bootstrap/locals.tf
+++ b/src/terraform/bootstrap/locals.tf
@@ -1,0 +1,14 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+  account_id  = data.aws_caller_identity.current.account_id
+
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform"
+    Component   = "bootstrap"
+  }
+}

--- a/src/terraform/bootstrap/main.tf
+++ b/src/terraform/bootstrap/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.40"
+    }
+  }
+
+  # Bootstrap uses the local backend — its state is managed manually and
+  # backed up to the `aws_s3_bucket.bootstrap_state` bucket created here.
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/src/terraform/bootstrap/outputs.tf
+++ b/src/terraform/bootstrap/outputs.tf
@@ -1,0 +1,34 @@
+output "state_bucket_name" {
+  description = "Name of the S3 bucket for root-module Terraform state"
+  value       = aws_s3_bucket.terraform_state.id
+}
+
+output "dynamodb_table_name" {
+  description = "Name of the DynamoDB table for state locking"
+  value       = aws_dynamodb_table.terraform_locks.id
+}
+
+output "backend_config" {
+  description = "Backend configuration values for the root module"
+  value = {
+    bucket         = aws_s3_bucket.terraform_state.id
+    key            = var.state_key
+    region         = var.aws_region
+    dynamodb_table = aws_dynamodb_table.terraform_locks.id
+    encrypt        = true
+  }
+}
+
+output "bootstrap_state_bucket_name" {
+  description = "Name of the S3 bucket for backing up bootstrap terraform.tfstate"
+  value       = aws_s3_bucket.bootstrap_state.id
+}
+
+output "bootstrap_state_backup_commands" {
+  description = "Commands to backup and restore bootstrap state"
+  value = {
+    upload   = "aws s3 cp terraform.tfstate s3://${aws_s3_bucket.bootstrap_state.id}/terraform.tfstate"
+    download = "aws s3 cp s3://${aws_s3_bucket.bootstrap_state.id}/terraform.tfstate terraform.tfstate"
+    list     = "aws s3 ls s3://${aws_s3_bucket.bootstrap_state.id}/"
+  }
+}

--- a/src/terraform/bootstrap/state.tf
+++ b/src/terraform/bootstrap/state.tf
@@ -1,0 +1,75 @@
+################################################################################
+# S3 Bucket for Root-Module Terraform State
+################################################################################
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = "${local.name_prefix}-tfstate-${local.account_id}"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-tfstate"
+  })
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    id     = "DeleteOldVersions"
+    status = "Enabled"
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+  }
+}
+
+################################################################################
+# DynamoDB Table for State Locking
+################################################################################
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = "${local.name_prefix}-tflock"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name_prefix}-tflock"
+  })
+}

--- a/src/terraform/bootstrap/terraform.tfvars.example
+++ b/src/terraform/bootstrap/terraform.tfvars.example
@@ -1,0 +1,4 @@
+aws_region   = "eu-central-1"
+environment  = "dev"
+project_name = "aws-infra-template"
+state_key    = "root/terraform.tfstate"

--- a/src/terraform/bootstrap/variables.tf
+++ b/src/terraform/bootstrap/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "aws-infra-template"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "state_key" {
+  description = "S3 key for the root-module Terraform state file"
+  type        = string
+  default     = "root/terraform.tfstate"
+}

--- a/src/terraform/data.tf
+++ b/src/terraform/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/src/terraform/locals.tf
+++ b/src/terraform/locals.tf
@@ -1,0 +1,16 @@
+locals {
+  name_prefix = "${var.project_name}-${var.environment}"
+
+  common_tags = {
+    Environment = var.environment
+    Project     = var.project_name
+    ManagedBy   = "terraform"
+  }
+
+  # Network CIDR blocks derived from var.vpc_cidr.
+  network_cidrs = {
+    public_a  = cidrsubnet(var.vpc_cidr, 8, 1)  # 10.0.1.0/24
+    public_b  = cidrsubnet(var.vpc_cidr, 8, 2)  # 10.0.2.0/24
+    private_a = cidrsubnet(var.vpc_cidr, 8, 10) # 10.0.10.0/24
+  }
+}

--- a/src/terraform/main.tf
+++ b/src/terraform/main.tf
@@ -1,0 +1,33 @@
+################################################################################
+# Networking
+################################################################################
+
+module "networking" {
+  source = "./modules/networking"
+
+  name_prefix = local.name_prefix
+  region      = data.aws_region.current.region
+  vpc_cidr    = var.vpc_cidr
+  public_subnet_cidrs = [
+    local.network_cidrs.public_a,
+    local.network_cidrs.public_b,
+  ]
+  private_subnet_cidrs = [
+    local.network_cidrs.private_a,
+  ]
+
+  tags = local.common_tags
+}
+
+################################################################################
+# Storage
+################################################################################
+
+module "storage" {
+  source = "./modules/storage"
+
+  name_prefix = local.name_prefix
+  bucket_name = var.bucket_name
+
+  tags = local.common_tags
+}

--- a/src/terraform/modules/networking/main.tf
+++ b/src/terraform/modules/networking/main.tf
@@ -1,0 +1,117 @@
+################################################################################
+# Availability Zones Data Source
+################################################################################
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+################################################################################
+# VPC
+################################################################################
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-vpc"
+  })
+}
+
+################################################################################
+# Internet Gateway
+################################################################################
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-igw"
+  })
+}
+
+################################################################################
+# Public Subnets (2 AZs)
+################################################################################
+
+resource "aws_subnet" "public_a" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[0]
+  availability_zone       = data.aws_availability_zones.available.names[0]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-a"
+  })
+}
+
+resource "aws_subnet" "public_b" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.public_subnet_cidrs[1]
+  availability_zone       = data.aws_availability_zones.available.names[1]
+  map_public_ip_on_launch = true
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-b"
+  })
+}
+
+################################################################################
+# Private Subnet
+################################################################################
+
+resource "aws_subnet" "private_a" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.private_subnet_cidrs[0]
+  availability_zone = data.aws_availability_zones.available.names[0]
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-a"
+  })
+}
+
+################################################################################
+# Route Tables
+################################################################################
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-public-rt"
+  })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-private-rt"
+  })
+}
+
+################################################################################
+# Route Table Associations
+################################################################################
+
+resource "aws_route_table_association" "public_a" {
+  subnet_id      = aws_subnet.public_a.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public_b" {
+  subnet_id      = aws_subnet.public_b.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private_a" {
+  subnet_id      = aws_subnet.private_a.id
+  route_table_id = aws_route_table.private.id
+}

--- a/src/terraform/modules/networking/outputs.tf
+++ b/src/terraform/modules/networking/outputs.tf
@@ -1,0 +1,34 @@
+output "vpc_id" {
+  description = "The ID of the VPC"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr_block" {
+  description = "The CIDR block of the VPC"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "internet_gateway_id" {
+  description = "The ID of the Internet Gateway"
+  value       = aws_internet_gateway.main.id
+}
+
+output "public_subnet_ids" {
+  description = "List of IDs of public subnets"
+  value       = [aws_subnet.public_a.id, aws_subnet.public_b.id]
+}
+
+output "private_subnet_ids" {
+  description = "List of IDs of private subnets"
+  value       = [aws_subnet.private_a.id]
+}
+
+output "public_route_table_id" {
+  description = "The ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "The ID of the private route table"
+  value       = aws_route_table.private.id
+}

--- a/src/terraform/modules/networking/variables.tf
+++ b/src/terraform/modules/networking/variables.tf
@@ -1,0 +1,42 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "Must be a valid IPv4 CIDR block"
+  }
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of CIDR blocks for public subnets (at least 2 AZs)"
+  type        = list(string)
+  validation {
+    condition     = length(var.public_subnet_cidrs) >= 2
+    error_message = "At least 2 public subnets are required"
+  }
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of CIDR blocks for private subnets"
+  type        = list(string)
+  validation {
+    condition     = length(var.private_subnet_cidrs) >= 1
+    error_message = "At least 1 private subnet is required"
+  }
+}
+
+variable "region" {
+  description = "AWS region (reserved for region-scoped resources)"
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to all networking resources"
+  type        = map(string)
+  default     = {}
+}

--- a/src/terraform/modules/storage/main.tf
+++ b/src/terraform/modules/storage/main.tf
@@ -1,0 +1,65 @@
+################################################################################
+# S3 Bucket
+################################################################################
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_s3_bucket" "bucket" {
+  bucket = "${var.bucket_name}-${data.aws_caller_identity.current.account_id}"
+
+  tags = merge(var.tags, {
+    Name = "${var.name_prefix}-${var.bucket_name}"
+  })
+}
+
+resource "aws_s3_bucket_public_access_block" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "bucket" {
+  bucket = aws_s3_bucket.bucket.id
+
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_tls_only" {
+  bucket = aws_s3_bucket.bucket.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyInsecureTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.bucket.arn,
+          "${aws_s3_bucket.bucket.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/src/terraform/modules/storage/outputs.tf
+++ b/src/terraform/modules/storage/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = aws_s3_bucket.bucket.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = aws_s3_bucket.bucket.arn
+}
+
+output "bucket_regional_domain_name" {
+  description = "Regional domain name of the S3 bucket"
+  value       = aws_s3_bucket.bucket.bucket_regional_domain_name
+}

--- a/src/terraform/modules/storage/variables.tf
+++ b/src/terraform/modules/storage/variables.tf
@@ -1,0 +1,24 @@
+variable "bucket_name" {
+  description = "Base name of the S3 bucket — the AWS account ID is appended for global uniqueness"
+  type        = string
+
+  validation {
+    condition = (
+      length(var.bucket_name) >= 3 &&
+      length(var.bucket_name) <= 50 &&
+      can(regex("^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$", var.bucket_name))
+    )
+    error_message = "bucket_name must be 3-50 characters, use lowercase letters/numbers/hyphens, and start/end with a letter or number. The 50-char limit reserves room for '-<12-digit-account-id>'."
+  }
+}
+
+variable "name_prefix" {
+  description = "Prefix for Name tag"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags to apply to the bucket"
+  type        = map(string)
+  default     = {}
+}

--- a/src/terraform/outputs.tf
+++ b/src/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "ID of the VPC created by the networking module"
+  value       = module.networking.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = module.networking.public_subnet_ids
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = module.networking.private_subnet_ids
+}
+
+output "bucket_name" {
+  description = "Name of the S3 bucket"
+  value       = module.storage.bucket_name
+}
+
+output "bucket_arn" {
+  description = "ARN of the S3 bucket"
+  value       = module.storage.bucket_arn
+}

--- a/src/terraform/providers.tf
+++ b/src/terraform/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = var.aws_region
+}

--- a/src/terraform/terraform.tfvars.example
+++ b/src/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Copy this file to terraform.tfvars and adjust values for your project.
+# terraform.tfvars is gitignored.
+
+aws_region   = "eu-central-1"
+environment  = "dev"
+project_name = "aws-infra-template"
+vpc_cidr     = "10.0.0.0/16"
+bucket_name  = "ait-storage"

--- a/src/terraform/variables.tf
+++ b/src/terraform/variables.tf
@@ -1,0 +1,29 @@
+variable "aws_region" {
+  description = "AWS region to deploy resources"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "environment" {
+  description = "Environment name"
+  type        = string
+  default     = "dev"
+}
+
+variable "project_name" {
+  description = "Project name used for resource naming and tagging"
+  type        = string
+  default     = "aws-infra-template"
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "bucket_name" {
+  description = "Base name of the S3 bucket (the account ID will be appended for global uniqueness)"
+  type        = string
+  default     = "ait-storage"
+}

--- a/src/terraform/versions.tf
+++ b/src/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.14"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.40"
+    }
+  }
+}

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,147 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "distlib"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.28.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/17/6e8890271880903e3538660a21d63a6c1fea969ac71d0d6b608b78727fa9/filelock-3.28.0.tar.gz", hash = "sha256:4ed1010aae813c4ee8d9c660e4792475ee60c4a0ba76073ceaf862bd317e3ca6", size = 56474, upload-time = "2026-04-14T22:54:33.625Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/21/2f728888c45033d34a417bfcd248ea2564c9e08ab1bfd301377cf05d5586/filelock-3.28.0-py3-none-any.whl", hash = "sha256:de9af6712788e7171df1b28b15eba2446c69721433fa427a9bee07b17820a9db", size = 39189, upload-time = "2026-04-14T22:54:32.037Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/f1/6d86a29246dfd2e9b6237f0b5823717f60cad94d47ddc26afa916d21f525/pre_commit-4.5.1.tar.gz", hash = "sha256:eb545fcff725875197837263e977ea257a402056661f09dae08e4b149b030a61", size = 198232, upload-time = "2025-12-16T21:14:33.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/19/fd3ef348460c80af7bb4669ea7926651d1f95c23ff2df18b9d24bab4f3fa/pre_commit-4.5.1-py2.py3-none-any.whl", hash = "sha256:3b3afd891e97337708c1674210f8eba659b52a38ea5f822ff142d10786221f77", size = 226437, upload-time = "2025-12-16T21:14:32.409Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "aws-infra-template"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pre-commit" },
+]
+lint = [
+    { name = "pre-commit" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pre-commit" }]
+lint = [{ name = "pre-commit" }]
+test = []
+
+[[package]]
+name = "virtualenv"
+version = "21.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/3a7e644e19cb26133488caff231be390579860bbbb3da35913c49a1d0a46/virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada", size = 5850742, upload-time = "2026-04-14T22:15:31.438Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/8d/edd0bd910ff803c308ee9a6b7778621af0d10252219ad9f19ef4d4982a61/virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac", size = 5831232, upload-time = "2026-04-14T22:15:29.342Z" },
+]


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

This PR scaffolds the aws-infra-template repository with a complete Terraform baseline and supporting project tooling. It establishes reusable infrastructure modules, bootstrap state management, linting and CI workflows, and AI coding guidance so new projects can start from a consistent foundation.

## Changes

- Add Terraform root and bootstrap modules under src/terraform, including backend, providers, variables, outputs, and lockfiles.
- Add reusable module implementations for networking and storage under src/terraform/modules.
- Add repository tooling and standards files such as Makefile, .mise.toml, pre-commit configuration, .editorconfig, and .gitattributes.
- Add CI and automation configuration in .github for linting, conventional commits, Dependabot, and Renovate.
- Add AI and developer guidance in README.md, docs/ai-instructions.md, CLAUDE.md, and .claude/skills.
- Add helper scripts for Terraform validation and AWS authentication flows.

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally
