### PR TITLE
ci: add commitlint, actionlint, Checkov, and dev-env init target

### DIFF
--- a/.checkov.yaml
+++ b/.checkov.yaml
@@ -1,0 +1,84 @@
+---
+# Checkov static analysis for Terraform.
+# Docs: https://www.checkov.io/2.Basics/CLI%20Command%20Reference.html
+#
+# Every skip below must document *why* it is skipped. Two categories exist:
+#
+#   (intentional) — a deliberate template default that users are expected to
+#                   override for their workloads. Do not remove.
+#   (TODO)        — a finding worth fixing at the template level but deferred.
+#                   Remove the skip once the underlying resource is updated.
+
+framework:
+  - terraform
+
+compact: true
+quiet: true
+
+# Limit the scan to the Terraform tree; matches the scope of the
+# terraform_tflint and terraform-validate-* hooks.
+directory:
+  - src/terraform
+
+skip-check:
+  # (intentional) Public subnets in the networking module are public by design
+  # and set map_public_ip_on_launch = true. Users who want private-only
+  # networking should not instantiate the public subnet resources.
+  - CKV_AWS_130  # VPC subnets should not assign public IP by default
+
+  # (intentional) The storage module's S3 bucket primitive uses AES-256 as a
+  # zero-cost default so the template works without provisioning a
+  # customer-managed KMS key. Users should override to aws:kms or a CMK for
+  # regulated workloads. The bootstrap state bucket already uses aws:kms.
+  - CKV_AWS_145  # S3 buckets should be encrypted with KMS (CMK)
+
+  # (intentional) Cross-region replication is a per-workload decision with
+  # material cost and an extra IAM role. The template ships single-region; add
+  # replication at the call site when the data classification requires it.
+  - CKV_AWS_144  # S3 cross-region replication
+
+  # (intentional) Access logging requires a separate logging bucket and is an
+  # app-level concern. The storage module is a minimal primitive; callers wire
+  # up logging when they add an audit trail.
+  - CKV_AWS_18   # S3 access logging
+
+  # (intentional) Event notifications are app-specific (SNS/SQS/Lambda targets).
+  # No sensible default exists at the template layer.
+  - CKV2_AWS_62  # S3 event notifications
+
+  # (intentional) Lifecycle rules on the app storage bucket depend on data
+  # retention policy, which is workload-specific. Bootstrap state buckets
+  # already have lifecycle configured.
+  - CKV2_AWS_61  # S3 bucket lifecycle configuration
+
+  # (intentional) Versioning on the app storage bucket is a data-classification
+  # decision (cost vs recoverability). The bootstrap state buckets already have
+  # versioning enabled because terraform state must be recoverable.
+  - CKV_AWS_21   # S3 versioning
+
+  # (intentional) The Terraform lock table stores ephemeral lock records; a
+  # lost row simply forces the next run to re-acquire the lock. PITR would add
+  # cost for no recovery benefit.
+  - CKV_AWS_28   # DynamoDB point-in-time recovery
+
+  # (intentional) The lock table contains no sensitive data and is encrypted by
+  # default with an AWS-owned key. A CMK would add per-key cost for no security
+  # improvement on this asset.
+  - CKV_AWS_119  # DynamoDB encryption with KMS CMK
+
+  # (TODO) Bootstrap lifecycle rules should also abort incomplete multipart
+  # uploads after N days to prevent orphaned part accumulation. Add
+  # `abort_incomplete_multipart_upload { days_after_initiation = 7 }` to both
+  # lifecycle rules in src/terraform/bootstrap/ and remove this skip.
+  - CKV_AWS_300  # S3 lifecycle should abort failed uploads
+
+  # (TODO) The default security group in the VPC is not explicitly locked down.
+  # Add an `aws_default_security_group` resource with no ingress/egress rules
+  # in modules/networking/ and remove this skip.
+  - CKV2_AWS_12  # Default security group restricts all traffic
+
+  # (TODO) VPC flow logs add ongoing cost (CloudWatch Logs or S3 ingest + storage)
+  # and are usually an observability-layer decision. Consider adding an opt-in
+  # variable to the networking module that provisions flow logs to a
+  # user-supplied log destination.
+  - CKV2_AWS_11  # VPC flow logging

--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,22 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [
+      2,
+      "always",
+      [
+        "build",
+        "chore",
+        "ci",
+        "docs",
+        "feat",
+        "fix",
+        "perf",
+        "refactor",
+        "revert",
+        "style",
+        "test"
+      ]
+    ]
+  }
+}

--- a/.cspell/project-words.txt
+++ b/.cspell/project-words.txt
@@ -12,3 +12,10 @@ pyml
 allfiles
 tfenv
 tflock
+
+# Conventional Commits tooling
+amannn
+commitlint
+commitlintrc
+vivaxy
+wagoid

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,20 @@
+# actionlint configuration
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+#
+# actionlint's built-in checks (syntax, expression typing, shellcheck / pyflakes
+# integration for `run:` steps, action input validation, etc.) run by default
+# and need no configuration. This file only declares project-specific values
+# that actionlint cannot otherwise know about, so it can avoid false positives
+# without weakening its checks.
+
+# Labels of self-hosted runners used by workflows in this repo.
+# Declare each label here so actionlint does not flag `runs-on:` values it
+# does not recognise. Leave empty while all jobs use GitHub-hosted runners.
+self-hosted-runner:
+  labels: []
+
+# Names of repository / organisation / environment configuration variables
+# referenced via `vars.*` in workflows. Declare each variable here so actionlint
+# can validate `vars.<name>` expressions against this allow-list and catch typos.
+# Leave empty while no workflow references `vars.*`.
+config-variables: []

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,5 +1,4 @@
 name: "On PR: Conventional Commits"
-# cspell:ignore amannn commitlint wagoid
 
 on:
   pull_request:
@@ -21,23 +20,26 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Extract allowed commit types from commitlint config
+        id: types
+        run: |
+          {
+            echo 'types<<EOF'
+            jq -r '.rules."type-enum"[2][]' .commitlintrc.json
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
       - name: Enforce Conventional Commit format in PR title
         uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            revert
-            style
-            test
+          types: ${{ steps.types.outputs.types }}
 
   commit-messages:
     name: Validate commit messages

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,14 @@ repos:
         args:
           - --args=--config=__GIT_WORKING_DIR__/.tflint.hcl
 
+  - repo: https://github.com/bridgecrewio/checkov
+    rev: 3.2.521
+    hooks:
+      - id: checkov
+        args:
+          - --config-file
+          - .checkov.yaml
+
   - repo: local
     hooks:
       - id: terraform-validate-root

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,14 @@ repos:
     hooks:
       - id: actionlint
 
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.24.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies:
+          - "@commitlint/config-conventional"
+
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.105.0
     hooks:

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,5 +7,6 @@
     "shd101wyy.markdown-preview-enhanced",
     "streetsidesoftware.code-spell-checker-cspell-bundled-dictionaries",
     "tylerharris.terraform-link-docs",
+    "vivaxy.vscode-conventional-commits",
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,13 @@ lint: ## Run all linters via pre-commit (yamllint, shellcheck, actionlint, terra
 install: ## Install Python dev dependencies via uv
 	$(UV) sync --frozen
 
+# ── First-time dev environment initialization ────────────────────────────────
+
+.PHONY: init-dev-env
+init-dev-env: install ## Initialize dev environment: install deps and enable git hooks
+	$(RUN) pre-commit install
+	$(RUN) pre-commit install --hook-type commit-msg
+
 # ── Update UV lock file ───────────────────────────────────────────────────────
 
 .PHONY: lock

--- a/README.md
+++ b/README.md
@@ -42,19 +42,18 @@ dependencies (currently just `pre-commit`) with [uv](https://docs.astral.sh/uv/)
 Common dev tasks are wrapped in the [Makefile](Makefile).
 
 ```bash
-brew install mise                             # macOS · one-time, bootstraps uv + terraform
-make lock                                     # generate uv.lock from pyproject.toml (first time)
-make install                                  # uv sync --frozen — create .venv from uv.lock
-mise exec -- uv run pre-commit install        # enable git hooks (once per clone)
-mise exec -- uv run pre-commit install --hook-type commit-msg  # enable commitlint
+brew install mise   # macOS · one-time, bootstraps uv + terraform
+make lock           # generate uv.lock from pyproject.toml (first time only)
+make init-dev-env   # install Python dev deps and enable git hooks
 ```
 
 Other handy targets:
 
 ```bash
-make help      # list all targets
-make lint      # run all pre-commit hooks against the whole repo
-make lock      # regenerate uv.lock after editing pyproject.toml
+make help           # list all targets
+make install        # re-sync .venv from uv.lock (after deps change)
+make lint           # run all pre-commit hooks against the whole repo
+make lock           # regenerate uv.lock after editing pyproject.toml
 make terraform-lock # regenerate Terraform lock files for macOS and Linux
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ brew install mise                             # macOS · one-time, bootstraps uv
 make lock                                     # generate uv.lock from pyproject.toml (first time)
 make install                                  # uv sync --frozen — create .venv from uv.lock
 mise exec -- uv run pre-commit install        # enable git hooks (once per clone)
+mise exec -- uv run pre-commit install --hook-type commit-msg  # enable commitlint
 ```
 
 Other handy targets:

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -195,6 +195,22 @@ aws-infra-template/
 Use Conventional Commits format: `type(scope): subject` — imperative mood, no trailing period.
 Example: `fix(ci): handle missing env variable`
 
+The allowed list of `type`s lives in [`.commitlintrc.json`](../.commitlintrc.json) and is
+the single source of truth shared by:
+
+- the local `commitlint` pre-commit hook (runs on `commit-msg` stage — see
+  [Pre-commit](#pre-commit) for install)
+- the [`vivaxy.vscode-conventional-commits`](https://marketplace.visualstudio.com/items?itemName=vivaxy.vscode-conventional-commits)
+  VS Code extension (reads `type-enum` directly from the commitlint config)
+- the [`wagoid/commitlint-github-action`](https://github.com/wagoid/commitlint-github-action)
+  job that validates commit messages on pull requests
+- the [`amannn/action-semantic-pull-request`](https://github.com/amannn/action-semantic-pull-request)
+  job that validates PR titles (the workflow extracts the list from
+  `.commitlintrc.json` via `jq` and passes it to the action)
+
+To add or remove a type, edit `rules.type-enum` in `.commitlintrc.json` only —
+all four consumers pick up the change automatically.
+
 ### Terraform
 
 - **Variable naming**: snake_case, descriptive names with `description` and `type` always set
@@ -235,16 +251,19 @@ The project uses [pre-commit](https://pre-commit.com) to enforce formatting and 
 | `pymarkdown`                   | Markdown files                                                       |
 | `shellcheck`                   | Shell scripts                                                        |
 | `actionlint`                   | GitHub Actions workflows                                             |
+| `commitlint`                   | Commit messages (`commit-msg` stage) — config in `.commitlintrc.json` |
 
 Both `terraform-validate-*` hooks call [scripts/terraform-validate-module.sh](../scripts/terraform-validate-module.sh),
 which runs `terraform validate` through the repo-pinned `terraform` (via `mise exec`)
 against a single module with lock files in read-only mode. Root and bootstrap are validated independently — changes
 in one do not trigger validation of the other.
 
-Enable in a fresh clone (after `make install`):
+Enable in a fresh clone (after `make install`). The `commit-msg` hook type is
+required for the `commitlint` hook:
 
 ```bash
 mise exec -- uv run pre-commit install
+mise exec -- uv run pre-commit install --hook-type commit-msg
 ```
 
 Run against specific files (faster than `--all-files`):

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -245,6 +245,7 @@ The project uses [pre-commit](https://pre-commit.com) to enforce formatting and 
 | ------------------------------ | -------------------------------------------------------------------- |
 | `terraform_fmt`                | All `.tf` and `.tfvars` files                                        |
 | `terraform_tflint`             | Terraform lint checks on changed Terraform directories               |
+| `checkov`                      | Terraform security/compliance scan — config in `.checkov.yaml`       |
 | `terraform-validate-root`      | Root Terraform module under `src/terraform/` (excludes `bootstrap/`) |
 | `terraform-validate-bootstrap` | `src/terraform/bootstrap/` module                                    |
 | `yamllint`                     | YAML files                                                           |
@@ -257,6 +258,12 @@ Both `terraform-validate-*` hooks call [scripts/terraform-validate-module.sh](..
 which runs `terraform validate` through the repo-pinned `terraform` (via `mise exec`)
 against a single module with lock files in read-only mode. Root and bootstrap are validated independently — changes
 in one do not trigger validation of the other.
+
+`checkov` scans `src/terraform/` for AWS misconfigurations. Skipped checks are
+enumerated in [`.checkov.yaml`](../.checkov.yaml); each skip is categorised as
+either `(intentional)` — a deliberate template default — or `(TODO)` — a
+finding worth fixing at the template level. Remove the `(TODO)` skip when the
+underlying resource is updated.
 
 Enable in a fresh clone (after `make install`). The `commit-msg` hook type is
 required for the `commitlint` hook:

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -85,18 +85,18 @@ The [Makefile](../Makefile) wraps the most common dev tasks. All targets execute
 `mise exec -- uv` so they use the mise-pinned `uv` and the uv-managed virtualenv.
 
 ```bash
-make help        # list all targets
-make install     # uv sync --frozen  — install dev deps from uv.lock
-make lock        # uv lock           — regenerate uv.lock after editing pyproject.toml
-make lint        # uv run pre-commit run --all-files
+make help          # list all targets
+make init-dev-env  # first-time dev setup: install deps + enable git hooks
+make install       # uv sync --frozen  — install dev deps from uv.lock
+make lock          # uv lock           — regenerate uv.lock after editing pyproject.toml
+make lint          # uv run pre-commit run --all-files
 ```
 
 Typical bootstrap in a fresh clone:
 
 ```bash
-make lock               # generate uv.lock from pyproject.toml (first time only)
-make install            # creates .venv and installs pre-commit
-mise exec -- uv run pre-commit install   # enable git hooks
+make lock           # generate uv.lock from pyproject.toml (first time only)
+make init-dev-env   # install deps into .venv and enable pre-commit + commit-msg hooks
 ```
 
 After editing `pyproject.toml` (adding/removing/bumping a Python dev dep):
@@ -265,8 +265,8 @@ either `(intentional)` — a deliberate template default — or `(TODO)` — a
 finding worth fixing at the template level. Remove the `(TODO)` skip when the
 underlying resource is updated.
 
-Enable in a fresh clone (after `make install`). The `commit-msg` hook type is
-required for the `commitlint` hook:
+`make init-dev-env` enables both hook types in a fresh clone (the `commit-msg` type is
+required for the `commitlint` hook). If you need to install them manually:
 
 ```bash
 mise exec -- uv run pre-commit install


### PR DESCRIPTION
## Description

Adds three pre-commit hooks (commitlint, actionlint, Checkov) and a `make init-dev-env`
Makefile target to streamline first-time development environment setup. The Conventional
Commits type allow-list is centralised in `.commitlintrc.json` as the single source of
truth shared by the local hook, the VS Code extension, the PR title action, and the
commit-message validation workflow.

## Changes

- `.commitlintrc.json` — new commitlint config with the canonical list of allowed Conventional Commits types
- `.pre-commit-config.yaml` — added `commitlint` (commit-msg stage) and `checkov` hooks
- `.checkov.yaml` — new Checkov config scoped to `src/terraform/`, with documented skip justifications (`intentional` vs `TODO`)
- `.github/actionlint.yaml` — new actionlint config for self-hosted runner labels and `vars.*` allow-list
- `.github/workflows/conventional-commits.yml` — extract type list from `.commitlintrc.json` via `jq` so the workflow stays in sync with the config; added checkout step; bump version of checkout action
- `.vscode/extensions.json` — added `vivaxy.vscode-conventional-commits` recommendation
- `Makefile` — added `init-dev-env` target that installs Python deps and both pre-commit hook stages
- `README.md`, `docs/ai-instructions.md` — updated fresh-clone setup flow to use `make init-dev-env`

## Testing

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally