### PR TITLE
ci: bump Mise toolchain version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Mise toolchain
         uses: jdx/mise-action@v4
         with:
-          version: 2026.3.9
+          version: 2026.4.17
 
       - name: Install pinned Mise tools
         run: mise install


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

Bump the pinned Mise toolchain version in the lint workflow so CI uses the current toolchain release.

## Changes

- Update the Mise version from 2026.3.9 to 2026.4.17 in .github/workflows/lint.yml.

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified
- Ran make lint locally.

## Checklist

- [x] No secrets or credentials included
- [x] make lint passes locally