### PR TITLE
chore(ai): sync command permission policy for Claude and Copilot

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": [
+      "Bash(gh pr *)",
       "Bash(terraform fmt:*)",
       "Bash(terraform version:*)",
       "Bash(*/terraform fmt:*)",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,17 @@ Shared skills are defined in `.claude/skills/`. Use those skills and avoid creat
 
 ## Command execution permissions
 
-When evaluating or executing shell commands, GitHub Copilot should consult the workspace permissions declared in `.claude/settings.json` and follow them exactly. In particular:
+When evaluating or executing shell commands, GitHub Copilot should follow the shared
+auto-approve policy defined in [docs/ai-instructions.md](../docs/ai-instructions.md).
+Use these sources in this order:
 
-- Only allow commands that match patterns listed under `permissions.allow` in `.claude/settings.json`.
-- Never execute commands that match patterns listed under `permissions.deny` in `.claude/settings.json`.
+1. VS Code settings (workspace/user) allow/deny command rules
+2. `.claude/settings.json` (base rules)
+3. `.claude/settings.local.json` (local overrides, if present)
+
+If VS Code settings define allowed/denied command rules, GitHub Copilot must use those
+rules first; they override the shared policy from `.claude/settings*.json`.
+
+- Auto-approve only commands that match `permissions.allow`.
+- Never execute commands that match `permissions.deny`.
+- If a command is not explicitly allowed, request user confirmation before execution.

--- a/docs/ai-instructions.md
+++ b/docs/ai-instructions.md
@@ -43,6 +43,19 @@ Root-module child modules:
 | Tool versioning  | [`mise`](https://mise.jdx.dev) — pins `terraform`, `uv`, etc.     |
 | CI               | GitHub Actions                                                    |
 
+## Command Auto-Approve Rules
+
+Use a single shared source for command auto-approve rules across AI tools:
+
+- Base rules: `.claude/settings.json` under `permissions.allow` and `permissions.deny`
+- Local overrides (if present): `.claude/settings.local.json` under the same keys
+
+Policy for both Claude Code and GitHub Copilot:
+
+- Auto-approve only commands matching `permissions.allow`
+- Never execute commands matching `permissions.deny`
+- If a command is not explicitly allowed, request user confirmation instead of executing
+
 ## Workflow
 
 ### Deploy bootstrap resources (first time only)


### PR DESCRIPTION
## Description

Synchronizes command execution permission guidance so Claude Code and GitHub Copilot follow the same auto-approve policy and precedence. VS Code allow/deny settings are now explicitly defined as higher priority than shared repository policies to reduce ambiguity across tools. Closes #4.

## Changes

- Added a shared `Command Auto-Approve Rules` section in `docs/ai-instructions.md` and documented allow/deny behavior plus fallback confirmation.
- Updated `.github/copilot-instructions.md` to enforce command rule precedence: VS Code settings first, then `.claude/settings.json`, then `.claude/settings.local.json`.
- Updated `.claude/settings.json` allow-list to include `Bash(gh pr *)` for PR workflow command support.

## Testing

- [ ] Unit tests added / updated
- [x] Manually verified
- Ran `mise exec -- uv run pre-commit run --files docs/ai-instructions.md .github/copilot-instructions.md`.

## Checklist

- [x] No secrets or credentials included
- [ ] `make lint` passes locally