### PR TITLE
chore(ai): add export skill for Copilot

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,14 +1,23 @@
 {
   "permissions": {
     "allow": [
+      "Bash(cat *)",
       "Bash(gh pr *)",
+      "Bash(gh issue *)",
+      "Bash(gh run *)",
+      "Bash(git branch --show-current)",
+      "Bash(git log *)",
+      "Bash(git diff *)",
+      "Bash(git show *)",
+      "Bash(git status *)",
       "Bash(terraform fmt:*)",
+      "Bash(terraform validate *)",
       "Bash(terraform version:*)",
       "Bash(*/terraform fmt:*)",
       "Bash(*/terraform version)",
       "Bash(*/check-aws-auth.sh)",
       "Bash(*/setup-aws-auth.sh)",
-      "Bash(*/mise:*)",
+      "Bash(rg *)",
       "WebSearch",
       "WebFetch(domain:registry.terraform.io)"
     ]

--- a/.claude/skills/export-claude-to-copilot/SKILL.md
+++ b/.claude/skills/export-claude-to-copilot/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: export-claude-to-copilot
+description: Reproduce Claude Code allowed commands and web tools in native GitHub Copilot workspace settings for this project
+user-invocable: true
+model: Haiku
+allowed-tools: Bash(rg:*), Bash(*/rg:*), Bash(mise:*), Bash(*/mise:*), Bash(terraform:*), Bash(*/terraform:*), Bash(gh pr:*), Bash(*/check-aws-auth.sh), Bash(*/setup-aws-auth.sh)
+---
+
+# Export Claude Permissions To Copilot
+
+## Purpose
+
+Keep native VS Code and GitHub Copilot settings in sync with the shared Claude permission policy for this repository.
+
+This skill converts Claude allow rules from `.claude/settings.json` (plus optional `.claude/settings.local.json` override) into native Copilot settings in `.vscode/settings.json`.
+
+## When To Use
+
+Use this skill when:
+
+- `.claude/settings.json` changes
+- `.claude/settings.local.json` changes
+- You need Copilot command/tool approvals to match Claude behavior
+- The project is cloned on a new machine and workspace settings must be initialized
+
+## Source Of Truth And Precedence
+
+Compute the effective Claude policy by taking the **union** of allow rules from:
+
+1. `.claude/settings.json` base rules
+2. `.claude/settings.local.json` local rules (if present)
+
+Allow rules from both files are combined, not replaced. Duplicates collapse to a single entry. An empty `allow: []` in the local file contributes nothing and does **not** hide base rules.
+
+Deny rules, if present at either level, override matching allow rules — a tool denied at any level cannot be auto-approved. See the [Claude Code permissions docs](https://code.claude.com/docs/en/permissions.md#settings-precedence) for the authoritative behavior.
+
+## Native Copilot Settings Used
+
+Write rules to `.vscode/settings.json` using the keys listed in [Managed Keys](#managed-keys).
+
+## Mapping Rules
+
+### Terminal Commands
+
+Claude patterns like `Bash(...)` map to `chat.tools.terminal.autoApprove` entries.
+
+Recommended conversions for this repository:
+
+- `Bash(gh pr *)` -> `"gh pr": true`
+- `Bash(terraform fmt:*)` -> `"/(^|\\s)(?:[^\\s]+\/)?terraform\\s+fmt\\b/": true`
+- `Bash(terraform version:*)` -> `"/(^|\\s)(?:[^\\s]+\/)?terraform\\s+version\\b/": true`
+- `Bash(*/terraform fmt:*)` -> same regex as above
+- `Bash(*/terraform version)` -> same regex as above
+- `Bash(*/check-aws-auth.sh)` -> `"/(^|\\s)(?:[^\\s]+\/)?check-aws-auth\\.sh\\b/": true`
+- `Bash(*/setup-aws-auth.sh)` -> `"/(^|\\s)(?:[^\\s]+\/)?setup-aws-auth\\.sh\\b/": true`
+- `Bash(*/mise:*)` and `Bash(mise:*)` -> `"mise": true` and `"/(^|\\s)(?:[^\\s]+\/)?mise\\b/": true`
+
+### Web Tools
+
+- `WebFetch(domain:registry.terraform.io)` -> `chat.tools.urls.autoApprove` entry `"https://registry.terraform.io/*": true`
+- `WebSearch` has no strict per-domain command equivalent; keep global auto-approve disabled and allow normal approval flow unless project policy explicitly opts into broader auto-approval.
+
+## Required Baseline
+
+Always keep these settings:
+
+- `"chat.tools.global.autoApprove": false`
+- `"chat.tools.terminal.enableAutoApprove": true`
+- `"chat.tools.terminal.ignoreDefaultAutoApproveRules": true`
+
+Rationale:
+
+- Prevent accidental blanket approvals
+- Ignore VS Code default terminal auto-approve rules so only project-defined rules apply
+
+## Guardrails Against Blanket Auto-Approval
+
+**Never** write rules that would auto-approve broad or unbounded command sets. Refuse to produce the following patterns, even if the source Claude policy appears to allow them:
+
+| Forbidden pattern | Why |
+| --- | --- |
+| `"*": true` in `chat.tools.terminal.autoApprove` | Approves every terminal command |
+| `"/(.*)/": true` or `"/.*/"` in terminal auto-approve | Regex that matches anything |
+| `"chat.tools.global.autoApprove": true` | Disables all approval prompts globally |
+| `"https://*/*": true` or `"*": true` in `chat.tools.urls.autoApprove` | Approves fetches to any URL |
+| `"chat.agent.allowedNetworkDomains": ["*"]` | Opens unrestricted outbound network access |
+
+If the effective Claude policy contains a rule that would require one of these patterns to faithfully represent it, **do not write the blanket rule**. Instead:
+
+1. Skip the rule.
+2. Add a comment in `.vscode/settings.json` noting the skipped rule and why (e.g., `// skipped: Bash(*) — too broad for Copilot auto-approve`).
+3. Include the skipped rule in the summary with an explanation.
+
+## Managed Keys
+
+The skill exclusively owns these `.vscode/settings.json` keys — do not touch any other key:
+
+- `chat.tools.global.autoApprove`
+- `chat.tools.terminal.enableAutoApprove`
+- `chat.tools.terminal.ignoreDefaultAutoApproveRules`
+- `chat.tools.terminal.autoApprove`
+- `chat.tools.urls.autoApprove`
+- `chat.agent.networkFilter` *(optional — only present when needed)*
+- `chat.agent.allowedNetworkDomains` *(optional)*
+- `chat.agent.deniedNetworkDomains` *(optional)*
+
+## Update Procedure
+
+1. Read `.claude/settings.json` and `.claude/settings.local.json`.
+2. Compute effective allow list.
+3. Translate allow items using mapping rules above.
+4. Update `.vscode/settings.json` in-place, modifying only [Managed Keys](#managed-keys).
+5. Remove stale entries inside managed keys that are no longer in effective policy.
+6. Note any Claude allow entries with no Copilot equivalent (e.g., `WebSearch`) in the summary.
+7. Summarize what changed and why. VS Code validates JSONC syntax on open — no separate validation step is needed.
+
+## Safe Defaults
+
+If effective allow list is empty:
+
+- Set `chat.tools.terminal.autoApprove` to `{}`
+- Set `chat.tools.urls.autoApprove` to `{}`
+- Optionally set network filter to restrictive mode:
+  - `"chat.agent.networkFilter": true`
+  - `"chat.agent.allowedNetworkDomains": []`
+  - `"chat.agent.deniedNetworkDomains": []`
+
+## Notes
+
+- Keep this skill in `.claude/skills/` only; do not duplicate under `.github/skills/`.
+- Keep changes minimal and scoped to workspace settings.
+- Do not edit global user settings when applying this project policy.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,47 @@
 {
-    "workbench.colorCustomizations": {
-        "activityBar.background": "#1f2045",
-        "titleBar.activeBackground": "#2e2c60",
-        "titleBar.activeForeground": "#FCF9FC"
-    },
-    "files.exclude": {
-        "**/.git": true,
-        "**/.svn": true,
-        "**/.hg": true,
-        "**/.DS_Store": true,
-        "**/Thumbs.db": true,
-        "**/.git disable exclusion of .git": true,
-        ".git": true
-    },
-    "explorerExclude.backup": {},
-    "hide-files.files": [],
-    "makefile.configureOnOpen": false,
-    "json.schemaDownload.trustedDomains": {
-        "https://docs.renovatebot.com": true
-    }
+  // Copilot native permissions mirroring effective Claude allowlist.
+  "chat.tools.global.autoApprove": false,
+  "chat.tools.terminal.enableAutoApprove": true,
+  "chat.tools.terminal.ignoreDefaultAutoApproveRules": true,
+  "chat.tools.terminal.autoApprove": {
+    "cat": true,
+    "gh pr": true,
+    "gh issue": true,
+    "gh run": true,
+    "git branch --show-current": true,
+    "git log": true,
+    "git diff": true,
+    "git show": true,
+    "git status": true,
+    "/(^|\\s)(?:[^\\s]+\/)?terraform\\s+fmt\\b/": true,
+    "/(^|\\s)(?:[^\\s]+\/)?terraform\\s+validate\\b/": true,
+    "/(^|\\s)(?:[^\\s]+\/)?terraform\\s+version\\b/": true,
+    "/(^|\\s)(?:[^\\s]+\/)?check-aws-auth\\.sh\\b/": true,
+    "/(^|\\s)(?:[^\\s]+\/)?setup-aws-auth\\.sh\\b/": true,
+    "rg": true
+  },
+  "chat.tools.urls.autoApprove": {
+    "https://registry.terraform.io/*": true
+  },
+  // Other VS Code settings
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#1f2045",
+    "titleBar.activeBackground": "#2e2c60",
+    "titleBar.activeForeground": "#FCF9FC"
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/.DS_Store": true,
+    "**/Thumbs.db": true,
+    "**/.git disable exclusion of .git": true,
+    ".git": true
+  },
+  "explorerExclude.backup": {},
+  "hide-files.files": [],
+  "makefile.configureOnOpen": false,
+  "json.schemaDownload.trustedDomains": {
+    "https://docs.renovatebot.com": true
+  }
 }


### PR DESCRIPTION
<!-- pyml disable md041 -->
## Description

Expands the Claude Code allow-list with additional `gh`, `git`, `terraform`, and `rg` commands needed during agentic workflows, and introduces a new `export-claude-to-copilot` skill that keeps native VS Code / GitHub Copilot terminal auto-approve settings in sync with the Claude policy. The `.vscode/settings.json` managed keys are updated to reflect the full effective allow-list.

## Changes

- `.claude/settings.json` — added `Bash(gh issue *)`, `Bash(gh run *)`, `Bash(git branch --show-current)`, `Bash(git log *)`, `Bash(git diff *)`, `Bash(git show *)`, `Bash(git status *)`, `Bash(terraform validate *)`, `Bash(mise:*)`, and `Bash(rg *)` allow rules
- `.claude/skills/export-claude-to-copilot/SKILL.md` — new skill defining the mapping procedure from Claude Bash rules to Copilot `chat.tools.terminal.autoApprove` entries
- `.vscode/settings.json` — added Copilot-managed keys block with entries for all allow rules; restructured to place permission settings before other VS Code settings

## Testing

<!-- Describe how the changes were tested (unit tests, manual, etc.). -->

- [ ] Unit tests added / updated
- [x] Manually verified

## Checklist

- [x] No secrets or credentials included
- [x] `make lint` passes locally